### PR TITLE
Fix local app embedding in kiosk

### DIFF
--- a/kiosk_app/modules/ui/main_window.py
+++ b/kiosk_app/modules/ui/main_window.py
@@ -209,12 +209,8 @@ class MainWindow(QMainWindow):
                 svc.page_error.connect(lambda _msg, h=host: h.show_placeholder())
                 self.browser_services.append(svc)
             else:
-                w = LocalAppWidget(type("Tmp", (), {
-                    "launch_cmd": s.launch_cmd,
-                    "embed_mode": "native_window",
-                    "window_title_pattern": s.window_title_pattern or ".*",
-                    "web_url": None
-                })())
+                # Uebrige Quellen werden als lokale Anwendungen behandelt
+                w = LocalAppWidget(s)
                 self.source_widgets.append(w)
                 self.browser_services.append(None)
 

--- a/kiosk_app/modules/utils/config_loader.py
+++ b/kiosk_app/modules/utils/config_loader.py
@@ -34,6 +34,7 @@ class SourceSpec:
     window_title_pattern: Optional[str] = None
     window_class_pattern: Optional[str] = None
     web_url: Optional[str] = None
+    force_pattern_only: bool = False
 
 
 @dataclass
@@ -75,6 +76,7 @@ def _source_from_dict(d: Dict[str, Any]) -> SourceSpec:
         window_title_pattern=d.get("window_title_pattern"),
         window_class_pattern=d.get("window_class_pattern"),
         web_url=d.get("web_url"),
+        force_pattern_only=bool(d.get("force_pattern_only", False)),
     )
 
 


### PR DESCRIPTION
## Summary
- preserve force_pattern_only and other config fields when loading sources
- embed local applications using the full source spec

## Testing
- `python -m py_compile kiosk_app/modules/utils/config_loader.py kiosk_app/modules/ui/main_window.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils')*


------
https://chatgpt.com/codex/tasks/task_e_689d7546b2a883279c9ff60ff7861a2c