### PR TITLE
Ensure local apps embed correctly

### DIFF
--- a/kiosk_app/modules/services/local_app_service.py
+++ b/kiosk_app/modules/services/local_app_service.py
@@ -337,7 +337,14 @@ class LocalAppWidget(QWidget):
                 self.log.error("kein launch_cmd konfiguriert")
             else:
                 try:
+                    # Besser ohne Shell starten, damit die PID dem Zielprozess entspricht
+                    parts = shlex.split(cmd, posix=False)
+                    self.proc = subprocess.Popen(parts)
+                except Exception:
+                    # Fallback: Shell benutzen, falls die Aufteilung fehlschlaegt
                     self.proc = subprocess.Popen(cmd, shell=True)
+
+                try:
                     self.log.info("Prozess gestartet: %s", cmd)
                     if not self._expected_exe_upper:
                         self._expected_exe_upper = _expected_exe_from_cmd(cmd, self._class_re)

--- a/kiosk_app/modules/ui/main_window.py
+++ b/kiosk_app/modules/ui/main_window.py
@@ -213,7 +213,9 @@ class MainWindow(QMainWindow):
                     "launch_cmd": s.launch_cmd,
                     "embed_mode": "native_window",
                     "window_title_pattern": s.window_title_pattern or ".*",
-                    "web_url": None
+                    "window_class_pattern": s.window_class_pattern or "",
+                    "web_url": None,
+                    "force_pattern_only": getattr(s, "force_pattern_only", False)
                 })())
                 self.source_widgets.append(w)
                 self.browser_services.append(None)

--- a/kiosk_app/modules/utils/config_loader.py
+++ b/kiosk_app/modules/utils/config_loader.py
@@ -33,6 +33,7 @@ class SourceSpec:
     embed_mode: str = "native_window"
     window_title_pattern: Optional[str] = None
     window_class_pattern: Optional[str] = None
+    force_pattern_only: bool = False
     web_url: Optional[str] = None
 
 
@@ -74,6 +75,7 @@ def _source_from_dict(d: Dict[str, Any]) -> SourceSpec:
         embed_mode=d.get("embed_mode", "native_window"),
         window_title_pattern=d.get("window_title_pattern"),
         window_class_pattern=d.get("window_class_pattern"),
+        force_pattern_only=d.get("force_pattern_only", False),
         web_url=d.get("web_url"),
     )
 


### PR DESCRIPTION
## Summary
- launch local applications without spawning an extra shell so their windows can be embedded
- expose `force_pattern_only` in the config loader and pass all patterns to the local app widget

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_689d7546b2a883279c9ff60ff7861a2c