### PR TITLE
Add option to disable split screen layout

### DIFF
--- a/kiosk_app/modules/config.json
+++ b/kiosk_app/modules/config.json
@@ -20,6 +20,7 @@
   ],
   "ui": {
     "start_mode": "quad",
+    "split_enabled": true,
     "sidebar_width": 96,
     "nav_orientation": "left",
     "show_setup_on_start": false,

--- a/kiosk_app/modules/tests/test_config.py
+++ b/kiosk_app/modules/tests/test_config.py
@@ -7,7 +7,7 @@ def test_valid_config_loads(tmp_path: Path):
     cfg_data = {
         "browser_urls": ["http://127.0.0.1:8000","http://127.0.0.1:8001","http://127.0.0.1:8002"],
         "local_app": {"launch_cmd":"notepad.exe","embed_mode":"native_window","window_title_pattern":".*Notepad.*"},
-        "ui": {"start_mode":"single","sidebar_width":96},
+        "ui": {"start_mode":"single","sidebar_width":96, "split_enabled": False},
         "kiosk": {"monitor_index":0,"disable_system_keys":True}
     }
     p = tmp_path / "config.json"
@@ -15,6 +15,7 @@ def test_valid_config_loads(tmp_path: Path):
     cfg = load_config(p)
     assert isinstance(cfg, Config)
     assert cfg.ui.start_mode == "single"
+    assert cfg.ui.split_enabled is False
 
 def test_invalid_urls(tmp_path: Path):
     cfg_data = {

--- a/kiosk_app/modules/ui/main_window.py
+++ b/kiosk_app/modules/ui/main_window.py
@@ -48,6 +48,8 @@ class MainWindow(QMainWindow):
         self.num_sources = len(self.sources)
         self.current_page = 0
         self.page_size = 4
+        if not self.cfg.ui.split_enabled:
+            self.state.start_mode = "single"
 
         # Widgets fuer Quellen
         self.source_widgets: List[QWidget] = []
@@ -88,7 +90,8 @@ class MainWindow(QMainWindow):
             sc.activated.connect(lambda idx=i: self._select_by_position(idx))
         QShortcut(QKeySequence("Ctrl+Right"), self).activated.connect(lambda: self._page_delta(+1))
         QShortcut(QKeySequence("Ctrl+Left"), self).activated.connect(lambda: self._page_delta(-1))
-        QShortcut(QKeySequence("Ctrl+Q"), self).activated.connect(self.on_toggle_mode)
+        if self.cfg.ui.split_enabled:
+            QShortcut(QKeySequence("Ctrl+Q"), self).activated.connect(self.on_toggle_mode)
         QShortcut(QKeySequence("F11"), self).activated.connect(self.toggle_kiosk)
 
         # Services
@@ -125,7 +128,8 @@ class MainWindow(QMainWindow):
             width=self.cfg.ui.sidebar_width,
             orientation=self.cfg.ui.nav_orientation,
             enable_hamburger=self.cfg.ui.enable_hamburger,
-            logo_path=self.cfg.ui.logo_path
+            logo_path=self.cfg.ui.logo_path,
+            split_enabled=self.cfg.ui.split_enabled
         )
         self.sidebar.view_selected.connect(self.on_select_view)
         self.sidebar.toggle_mode.connect(self.on_toggle_mode)
@@ -172,8 +176,9 @@ class MainWindow(QMainWindow):
         m.addSeparator()
         act_show = m.addAction("Leiste anzeigen")
         act_show.triggered.connect(lambda: self.set_sidebar_collapsed(False))
-        act_switch = m.addAction("Switch")
-        act_switch.triggered.connect(self.on_toggle_mode)
+        if self.cfg.ui.split_enabled:
+            act_switch = m.addAction("Switch")
+            act_switch.triggered.connect(self.on_toggle_mode)
         act_settings = m.addAction("Einstellungen")
         act_settings.triggered.connect(self.open_settings)
         pos = self.overlay_burger.mapToGlobal(self.overlay_burger.rect().bottomLeft())
@@ -303,6 +308,7 @@ class MainWindow(QMainWindow):
             placeholder_gif_path=self.cfg.ui.placeholder_gif_path,
             theme=self.cfg.ui.theme,
             logo_path=self.cfg.ui.logo_path,
+            split_enabled=self.cfg.ui.split_enabled,
             parent=self
         )
         if dlg.exec():
@@ -394,6 +400,8 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def on_toggle_mode(self):
+        if not self.cfg.ui.split_enabled:
+            return
         self.state.toggle_mode()
         self.apply_mode(self.state.mode)
 

--- a/kiosk_app/modules/ui/settings_dialog.py
+++ b/kiosk_app/modules/ui/settings_dialog.py
@@ -138,6 +138,7 @@ class SettingsDialog(QDialog):
                  placeholder_gif_path: str,
                  theme: str,
                  logo_path: str,
+                 split_enabled: bool,
                  parent: Optional[QWidget] = None):
         super().__init__(parent)
 
@@ -220,6 +221,13 @@ class SettingsDialog(QDialog):
         body_l.addLayout(row3)
         body_l.addLayout(row4)
         body_l.addLayout(row5)
+        if not split_enabled:
+            info_lbl = QLabel(
+                "Hinweis: Splitscreen ist deaktiviert. Wechsel ueber die Sidebar, Strg+Q ist inaktiv.",
+                self,
+            )
+            info_lbl.setWordWrap(True)
+            body_l.addWidget(info_lbl)
 
         # ---------- Footer Aktionen ----------
         footer = QHBoxLayout()

--- a/kiosk_app/modules/ui/setup_dialog.py
+++ b/kiosk_app/modules/ui/setup_dialog.py
@@ -184,6 +184,10 @@ class SetupDialog(QDialog):
         self.count_spin.setValue(initial_count)
         self.count_spin.valueChanged.connect(self._rebuild_rows)
         hl.addWidget(self.count_spin)
+
+        self.split_cb = QCheckBox("Splitscreen aktiv", self)
+        self.split_cb.setChecked(True)
+        hl.addWidget(self.split_cb)
         hl.addStretch(1)
 
         # Scrollbereich
@@ -288,6 +292,16 @@ class SetupDialog(QDialog):
         self.rows_layout.addStretch(1)
 
     def _prefill_from_cfg(self, cfg):
+        try:
+            ui = getattr(cfg, "ui", None)
+            val = getattr(ui, "split_enabled", True) if ui is not None else True
+        except Exception:
+            try:
+                val = cfg.get("ui", {}).get("split_enabled", True)
+            except Exception:
+                val = True
+        self.split_cb.setChecked(bool(val))
+
         sources = getattr(cfg, "sources", []) or []
         try:
             # falls dict
@@ -368,7 +382,8 @@ class SetupDialog(QDialog):
         new_cfg: Dict[str, Any] = {
             "sources": specs,
             "ui": {
-                "start_mode": _get(ui, "start_mode", "quad"),
+                "start_mode": "quad" if self.split_cb.isChecked() else "single",
+                "split_enabled": bool(self.split_cb.isChecked()),
                 "sidebar_width": _get(ui, "sidebar_width", 96),
                 "nav_orientation": _get(ui, "nav_orientation", "left"),
                 "show_setup_on_start": False,

--- a/kiosk_app/modules/ui/sidebar.py
+++ b/kiosk_app/modules/ui/sidebar.py
@@ -87,7 +87,7 @@ class Sidebar(QWidget):
     collapsed_changed = Signal(bool)  # true = eingeklappt
 
     def __init__(self, titles: List[str], width: int = 96, orientation: str = "left",
-                 enable_hamburger: bool = True, logo_path: str = "", parent=None):
+                 enable_hamburger: bool = True, logo_path: str = "", split_enabled: bool = True, parent=None):
         super().__init__(parent)
         self._orientation = orientation  # "left" oder "top"
         self._all_titles = titles[:]
@@ -97,6 +97,7 @@ class Sidebar(QWidget):
         self._collapsed = False
         self._enable_hamburger = enable_hamburger
         self._logo_path = logo_path
+        self._split_enabled = split_enabled
 
         self.setObjectName("Sidebar")
         self._build_ui()
@@ -198,6 +199,7 @@ class Sidebar(QWidget):
         self.btn_toggle.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.btn_toggle.clicked.connect(self.toggle_mode.emit)
         root.addWidget(self.btn_toggle)
+        self.btn_toggle.setVisible(self._split_enabled)
 
         self._layout = root
 
@@ -264,6 +266,7 @@ class Sidebar(QWidget):
         self.btn_toggle.setToolTip("Strg+Q")
         self.btn_toggle.clicked.connect(self.toggle_mode.emit)
         layout.addWidget(self.btn_toggle)
+        self.btn_toggle.setVisible(self._split_enabled)
 
         # Freie Flaeche mit grossem Logo
         layout.addStretch(1)
@@ -295,7 +298,7 @@ class Sidebar(QWidget):
         self.buttons_wrap.setVisible(not collapsed)
         self.btn_prev.setVisible(not collapsed)
         self.btn_next.setVisible(not collapsed)
-        self.btn_toggle.setVisible(not collapsed)
+        self.btn_toggle.setVisible(self._split_enabled and not collapsed)
         if hasattr(self, "logo"):
             self.logo.setVisible(not collapsed)
         self._apply_thickness()

--- a/kiosk_app/modules/utils/config_loader.py
+++ b/kiosk_app/modules/utils/config_loader.py
@@ -42,6 +42,7 @@ class SourceSpec:
 @dataclass
 class UISettings:
     start_mode: str = "quad"                 # "single" oder "quad"
+    split_enabled: bool = True               # Splitscreen erlauben
     sidebar_width: int = 96
     nav_orientation: str = "left"            # "left" oder "top"
     show_setup_on_start: bool = False
@@ -225,6 +226,7 @@ def _parse_ui(data: Dict[str, Any]) -> UISettings:
     ui = data.get("ui") or {}
     return UISettings(
         start_mode=_safe_str(ui.get("start_mode") or "quad"),
+        split_enabled=_as_bool(ui, "split_enabled", True),
         sidebar_width=_as_int(ui, "sidebar_width", 96),
         nav_orientation=_safe_str(ui.get("nav_orientation") or "left"),
         show_setup_on_start=_as_bool(ui, "show_setup_on_start", False),


### PR DESCRIPTION
## Summary
- add `split_enabled` config and setup checkbox to disable split screen
- hide switch controls and shortcut when split screen disabled
- show info message in settings dialog when split screen is off

## Testing
- `PYTHONPATH=. pytest tests/test_config.py -q`
- `PYTHONPATH=. pytest tests/test_services.py -q` *(fails: ModuleNotFoundError: No module named 'services.browser_service')*


------
https://chatgpt.com/codex/tasks/task_e_68b96f9e468083279e8229cc76e903a6