### PR TITLE
Add runtime multi-language support and tests

### DIFF
--- a/kiosk_app/modules/tests/test_i18n.py
+++ b/kiosk_app/modules/tests/test_i18n.py
@@ -1,0 +1,31 @@
+import pytest
+from utils.i18n import i18n, tr
+
+
+def test_language_switching():
+    original = i18n.get_language()
+    try:
+        i18n.set_language("en")
+        assert tr("Settings") == "Settings"
+        i18n.set_language("de")
+        assert tr("Settings") == "Einstellungen"
+    finally:
+        i18n.set_language(original)
+
+
+def test_setup_dialog_retranslation():
+    QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+    from PySide6.QtWidgets import QApplication
+    from ui.setup_dialog import SetupDialog
+
+    app = QApplication.instance() or QApplication([])
+    original = i18n.get_language()
+    try:
+        i18n.set_language("en")
+        dlg = SetupDialog({})
+        assert dlg.windowTitle() == "Initial setup"
+        i18n.set_language("de")
+        assert dlg.windowTitle() == "Ersteinrichtung"
+    finally:
+        i18n.set_language(original)
+        dlg.close()

--- a/kiosk_app/modules/ui/setup_dialog.py
+++ b/kiosk_app/modules/ui/setup_dialog.py
@@ -9,6 +9,8 @@ from PySide6.QtWidgets import (
     QSpinBox, QGridLayout
 )
 
+from modules.utils.i18n import tr, i18n
+
 
 # ---------- Hilfs Widgets ----------
 
@@ -24,72 +26,83 @@ class _SourceRow(QWidget):
         grid.setVerticalSpacing(4)
 
         # Name
-        grid.addWidget(QLabel("Name"), 0, 0)
+        self.lbl_name = QLabel("", self)
+        grid.addWidget(self.lbl_name, 0, 0)
         self.name_edit = QLineEdit(self)
-        self.name_edit.setPlaceholderText(f"Quelle {idx+1}")
+        self.name_edit.setPlaceholderText("")
         grid.addWidget(self.name_edit, 0, 1, 1, 3)
 
         # Typ
-        grid.addWidget(QLabel("Typ"), 1, 0)
+        self.lbl_type = QLabel("", self)
+        grid.addWidget(self.lbl_type, 1, 0)
         self.type_combo = QComboBox(self)
-        self.type_combo.addItems(["browser", "local"])
-        self.type_combo.currentTextChanged.connect(self._on_type_change)
+        self.type_combo.addItem("", "browser")
+        self.type_combo.addItem("", "local")
+        self.type_combo.currentIndexChanged.connect(lambda idx: self._on_type_change(self.type_combo.itemData(idx)))
         grid.addWidget(self.type_combo, 1, 1)
 
         # Browser Felder
         self.url_edit = QLineEdit(self)
         self.url_edit.setPlaceholderText("https://example.com")
-        grid.addWidget(QLabel("URL"), 2, 0)
+        self.lbl_url = QLabel("", self)
+        grid.addWidget(self.lbl_url, 2, 0)
         grid.addWidget(self.url_edit, 2, 1, 1, 3)
 
         # Lokale App Felder
         self.exe_edit = QLineEdit(self)
-        self.exe_edit.setPlaceholderText("Pfad zur EXE")
-        self.exe_btn = QPushButton("Waehlen", self)
+        self.exe_edit.setPlaceholderText("")
+        self.exe_btn = QPushButton("", self)
         self.exe_btn.clicked.connect(self._browse_exe)
 
         self.args_edit = QLineEdit(self)
-        self.args_edit.setPlaceholderText("Optionale Argumente zB /safe oder -n 1")
+        self.args_edit.setPlaceholderText("")
 
         self.title_edit = QLineEdit(self)
-        self.title_edit.setPlaceholderText("Titel Regex zB .*Notepad.*")
+        self.title_edit.setPlaceholderText("")
 
         self.class_edit = QLineEdit(self)
-        self.class_edit.setPlaceholderText("Klasse Regex zB XLMAIN")
+        self.class_edit.setPlaceholderText("")
 
         self.child_class_edit = QLineEdit(self)
-        self.child_class_edit.setPlaceholderText("Child Klasse Regex zB Edit")
+        self.child_class_edit.setPlaceholderText("")
 
-        self.allow_global_cb = QCheckBox("Globalen Fallback erlauben", self)
-        self.follow_children_cb = QCheckBox("Kindprozessen folgen", self)
+        self.allow_global_cb = QCheckBox("", self)
+        self.follow_children_cb = QCheckBox("", self)
         self.follow_children_cb.setChecked(True)
 
         row = 3
-        grid.addWidget(QLabel("EXE"), row, 0)
+        self.lbl_exe = QLabel("", self)
+        grid.addWidget(self.lbl_exe, row, 0)
         grid.addWidget(self.exe_edit, row, 1, 1, 2)
         grid.addWidget(self.exe_btn, row, 3)
         row += 1
 
-        grid.addWidget(QLabel("Argumente"), row, 0)
+        self.lbl_args = QLabel("", self)
+        grid.addWidget(self.lbl_args, row, 0)
         grid.addWidget(self.args_edit, row, 1, 1, 3)
         row += 1
 
-        grid.addWidget(QLabel("Titel Regex"), row, 0)
+        self.lbl_title = QLabel("", self)
+        grid.addWidget(self.lbl_title, row, 0)
         grid.addWidget(self.title_edit, row, 1, 1, 3)
         row += 1
 
-        grid.addWidget(QLabel("Klasse Regex"), row, 0)
+        self.lbl_class = QLabel("", self)
+        grid.addWidget(self.lbl_class, row, 0)
         grid.addWidget(self.class_edit, row, 1, 1, 3)
         row += 1
 
-        grid.addWidget(QLabel("Child Klasse Regex"), row, 0)
+        self.lbl_child_class = QLabel("", self)
+        grid.addWidget(self.lbl_child_class, row, 0)
         grid.addWidget(self.child_class_edit, row, 1, 1, 3)
         row += 1
 
         grid.addWidget(self.follow_children_cb, row, 1)
         grid.addWidget(self.allow_global_cb, row, 2)
 
-        self._on_type_change(self.type_combo.currentText())
+        self._on_type_change(self.type_combo.itemData(self.type_combo.currentIndex()))
+        i18n.language_changed.connect(lambda _l: self.retranslate_ui())
+        self.retranslate_ui()
 
     def _on_type_change(self, typ: str):
         is_browser = typ == "browser"
@@ -106,14 +119,35 @@ class _SourceRow(QWidget):
             w.setVisible(not is_browser)
 
     def _browse_exe(self):
-        path, _ = QFileDialog.getOpenFileName(self, "EXE auswaehlen", "", "Programme (*.exe);;Alle Dateien (*)")
+        path, _ = QFileDialog.getOpenFileName(self, tr("Path to EXE"), "", "Programme (*.exe);;Alle Dateien (*)")
         if path:
             self.exe_edit.setText(path)
 
+    def retranslate_ui(self):
+        self.lbl_name.setText(tr("Name"))
+        self.name_edit.setPlaceholderText(tr("Source {num}", num=self.idx + 1))
+        self.lbl_type.setText(tr("Type"))
+        self.type_combo.setItemText(0, tr("browser"))
+        self.type_combo.setItemText(1, tr("local"))
+        self.lbl_url.setText(tr("URL"))
+        self.lbl_exe.setText(tr("Path to EXE"))
+        self.exe_edit.setPlaceholderText(tr("Path to EXE"))
+        self.exe_btn.setText(tr("Browse"))
+        self.lbl_args.setText(tr("Arguments"))
+        self.args_edit.setPlaceholderText(tr("Arguments"))
+        self.lbl_title.setText(tr("Title regex"))
+        self.title_edit.setPlaceholderText(tr("Title regex"))
+        self.lbl_class.setText(tr("Class regex"))
+        self.class_edit.setPlaceholderText(tr("Class regex"))
+        self.lbl_child_class.setText(tr("Child class regex"))
+        self.child_class_edit.setPlaceholderText(tr("Child class regex"))
+        self.allow_global_cb.setText(tr("Allow global fallback"))
+        self.follow_children_cb.setText(tr("Follow child processes"))
+
     def to_spec_dict(self) -> Dict[str, Any] | None:
         """Extrahiert die Zeile als SourceSpec dict oder None wenn unvollstaendig."""
-        typ = self.type_combo.currentText().strip().lower()
-        name = self.name_edit.text().strip() or f"Quelle {self.idx+1}"
+        typ = (self.type_combo.currentData() or "browser").strip().lower()
+        name = self.name_edit.text().strip() or tr("Source {num}", num=self.idx+1)
 
         if typ == "browser":
             url = self.url_edit.text().strip()
@@ -158,7 +192,7 @@ class SetupDialog(QDialog):
     """
     def __init__(self, cfg, parent: Optional[QWidget] = None):
         super().__init__(parent)
-        self.setWindowTitle("Ersteinrichtung")
+        self.setWindowTitle("")
         self.setModal(True)
         self.setMinimumSize(760, 560)
 
@@ -173,7 +207,8 @@ class SetupDialog(QDialog):
         header = QWidget(self)
         hl = QHBoxLayout(header)
         hl.setContentsMargins(12, 12, 12, 6)
-        hl.addWidget(QLabel("Anzahl Fenster"))
+        self.lbl_count = QLabel("", self)
+        hl.addWidget(self.lbl_count)
         self.count_spin = QSpinBox(self)
         self.count_spin.setRange(1, 20)
         initial_count = 4
@@ -185,7 +220,7 @@ class SetupDialog(QDialog):
         self.count_spin.valueChanged.connect(self._rebuild_rows)
         hl.addWidget(self.count_spin)
 
-        self.split_cb = QCheckBox("Splitscreen aktiv", self)
+        self.split_cb = QCheckBox("", self)
         self.split_cb.setChecked(True)
         hl.addWidget(self.split_cb)
         hl.addStretch(1)
@@ -204,11 +239,11 @@ class SetupDialog(QDialog):
         fl = QHBoxLayout(footer)
         fl.setContentsMargins(12, 6, 12, 12)
 
-        self.overwrite_cb = QCheckBox("Config ueberschreiben", self)
+        self.overwrite_cb = QCheckBox("", self)
         self.overwrite_cb.setChecked(True)
 
-        self.cancel_btn = QPushButton("Abbrechen", self)
-        self.save_btn = QPushButton("Speichern", self)
+        self.cancel_btn = QPushButton("", self)
+        self.save_btn = QPushButton("", self)
 
         fl.addWidget(self.overwrite_cb)
         fl.addStretch(1)
@@ -232,6 +267,9 @@ class SetupDialog(QDialog):
         self._prefill_from_cfg(cfg)
 
         self._result: Dict[str, Any] = {}
+
+        i18n.language_changed.connect(lambda _l: self._apply_translations())
+        self._apply_translations()
 
     # -------- Theme --------
 
@@ -290,6 +328,7 @@ class SetupDialog(QDialog):
             self._rows.append(row)
             self.rows_layout.addWidget(row)
         self.rows_layout.addStretch(1)
+        self._apply_translations()
 
     def _prefill_from_cfg(self, cfg):
         try:
@@ -315,14 +354,14 @@ class SetupDialog(QDialog):
             if self._rows:
                 # erste drei Browser
                 for i in range(min(3, len(self._rows))):
-                    self._rows[i].type_combo.setCurrentText("browser")
-                    self._rows[i].name_edit.setText(f"Browser {i+1}")
+                    self._rows[i].type_combo.setCurrentIndex(0)
+                    self._rows[i].name_edit.setText(f"{tr('browser').capitalize()} {i+1}")
                     self._rows[i].url_edit.setText("https://www.google.com")
                 # ein lokaler Editor
                 if len(self._rows) >= 4:
                     r = self._rows[3]
-                    r.type_combo.setCurrentText("local")
-                    r.name_edit.setText("Editor")
+                    r.type_combo.setCurrentIndex(1)
+                    r.name_edit.setText(tr('local').capitalize())
                     r.exe_edit.setText("C:\\Windows\\System32\\notepad.exe")
                     r.title_edit.setText(".*(Notepad|Editor).*")
                     r.child_class_edit.setText("Edit")
@@ -338,11 +377,11 @@ class SetupDialog(QDialog):
                 r = self._rows[i]
                 r.name_edit.setText(s_name)
                 if s_type == "browser":
-                    r.type_combo.setCurrentText("browser")
+                    r.type_combo.setCurrentIndex(0)
                     url = getattr(s, "url", None) or s.get("url", "")
                     r.url_edit.setText(url)
                 else:
-                    r.type_combo.setCurrentText("local")
+                    r.type_combo.setCurrentIndex(1)
                     r.exe_edit.setText(getattr(s, "launch_cmd", None) or s.get("launch_cmd", ""))
                     r.args_edit.setText(getattr(s, "args", None) or s.get("args", ""))
                     r.title_edit.setText(getattr(s, "window_title_pattern", None) or s.get("window_title_pattern", "") or "")
@@ -352,6 +391,19 @@ class SetupDialog(QDialog):
                     r.follow_children_cb.setChecked(bool(getattr(s, "follow_children", None) or s.get("follow_children", True)))
             except Exception:
                 continue
+
+    def _apply_translations(self):
+        self.setWindowTitle(tr("Initial setup"))
+        self.lbl_count.setText(tr("Number of windows"))
+        self.split_cb.setText(tr("Split screen active"))
+        self.overwrite_cb.setText(tr("Overwrite config"))
+        self.cancel_btn.setText(tr("Cancel"))
+        self.save_btn.setText(tr("Save"))
+        for r in self._rows:
+            try:
+                r.retranslate_ui()
+            except Exception:
+                pass
 
     # -------- Speichern --------
 
@@ -363,7 +415,7 @@ class SetupDialog(QDialog):
                 specs.append(spec)
 
         if not specs:
-            QMessageBox.warning(self, "Ungueltig", "Bitte mindestens eine gueltige Quelle angeben.")
+            QMessageBox.warning(self, tr("Invalid"), tr("Please provide at least one valid source."))
             return
 
         # Aktuelle UI und Kiosk Werte aus cfg lesen, robust gegen Dict oder Objekt

--- a/kiosk_app/modules/utils/i18n.py
+++ b/kiosk_app/modules/utils/i18n.py
@@ -98,6 +98,7 @@ class LanguageManager(QObject):
                 "Overwrite config": "Overwrite config",
                 "Invalid": "Invalid",
                 "Please provide at least one valid source.": "Please provide at least one valid source.",
+                "Source {num}": "Source {num}",
             },
             "de": {
                 "Settings": "Einstellungen",
@@ -177,6 +178,7 @@ class LanguageManager(QObject):
                 "Overwrite config": "Config überschreiben",
                 "Invalid": "Ungültig",
                 "Please provide at least one valid source.": "Bitte mindestens eine gültige Quelle angeben.",
+                "Source {num}": "Quelle {num}",
             },
         }
 


### PR DESCRIPTION
## Summary
- localize setup dialog UI and hook it into runtime language switching
- extend translation catalog with setup strings and dynamic "Source {num}" placeholders
- add tests exercising language switching and setup dialog translation

## Testing
- `PYTHONPATH=kiosk_app/modules pytest kiosk_app/modules/tests/test_config.py -q`
- `PYTHONPATH=kiosk_app/modules pytest kiosk_app/modules/tests/test_i18n.py -q`
- `PYTHONPATH=kiosk_app/modules pytest kiosk_app/modules/tests/test_services.py -q` *(fails: ModuleNotFoundError: No module named 'services.browser_service')*


------
https://chatgpt.com/codex/tasks/task_e_68b98831c4e88327a1b1644bbcd73da2