### PR TITLE
Add bilingual installation and usage guides

### DIFF
--- a/docs/ANLEITUNG_DE.md
+++ b/docs/ANLEITUNG_DE.md
@@ -1,0 +1,44 @@
+# MultiScreenKiosk – Installations-, Konfigurations- und Bedienungsanleitung
+
+## Installation
+
+1. **Voraussetzungen**
+   - Windows 10 oder neuer
+2. **Download**
+   - Neueste Release von der Projektseite herunterladen.
+3. **Start**
+   - Ggf. ZIP entpacken und `MultiScreenKiosk.exe` ausführen.
+
+## Konfiguration
+
+1. **Erster Start**
+   - `MultiScreenKiosk.exe --setup`
+   - Dialog zum Festlegen der **Anzahl der Fenster** und **Quellen**.
+2. **Konfigurationsdatei**
+   - Pfad: `kiosk_app/modules/config.json`
+   - Struktur-Beispiel:
+     ```json
+     {
+       "sources": [{"type": "browser", "name": "Google", "url": "https://www.google.com"}],
+       "ui": {"start_mode": "single", "shortcuts": {}},
+       "kiosk": {"monitor_index": 0, "kiosk_fullscreen": true}
+     }
+     ```
+   - Alternativ über den Setup‑Dialog erzeugen lassen.
+
+## Bedienung
+
+1. **Starten**
+   - Standard: `MultiScreenKiosk.exe`
+   - Optionen:
+     - `--config PATH` – alternativen Konfigurationspfad verwenden
+     - `--setup` – Setup-Dialog erneut öffnen
+     - `--log-level LVL` – Log‑Level überschreiben (DEBUG, INFO, …)
+2. **Tastenkürzel**
+   - `Ctrl+1…4` – Pane auswählen
+   - `Ctrl+Q` – Einzel-/Vierfachansicht umschalten
+   - `F11` – Kiosk-Vollbild an/aus
+   - `Shift + Schließen` – Beenden im Kiosk-Modus
+3. **Logging**
+   - Logdateien unter `%LOCALAPPDATA%\\MultiScreenKiosk\\logs`
+   - Pro Start: `YYYYMMDD_N_Logfile.log`

--- a/docs/MANUAL_EN.md
+++ b/docs/MANUAL_EN.md
@@ -1,0 +1,44 @@
+# MultiScreenKiosk – Installation, Configuration and Operation Guide
+
+## Installation
+
+1. **Requirements**
+   - Windows 10 or newer
+2. **Download**
+   - Fetch the latest release from the project page.
+3. **Start**
+   - Unzip if necessary and run `MultiScreenKiosk.exe`.
+
+## Configuration
+
+1. **First run**
+   - `MultiScreenKiosk.exe --setup`
+   - Dialog to define **number of panes** and **sources**.
+2. **Configuration file**
+   - Path: `kiosk_app/modules/config.json`
+   - Example structure:
+     ```json
+     {
+       "sources": [{"type": "browser", "name": "Google", "url": "https://www.google.com"}],
+       "ui": {"start_mode": "single", "shortcuts": {}},
+       "kiosk": {"monitor_index": 0, "kiosk_fullscreen": true}
+     }
+     ```
+   - Alternatively generate via the setup dialog.
+
+## Operation
+
+1. **Start**
+   - Default: `MultiScreenKiosk.exe`
+   - Options:
+     - `--config PATH` – use custom config path
+     - `--setup` – force the setup dialog
+     - `--log-level LVL` – override log level (DEBUG, INFO, …)
+2. **Keyboard shortcuts**
+   - `Ctrl+1…4` – select pane
+   - `Ctrl+Q` – toggle single/quad view
+   - `F11` – toggle kiosk fullscreen
+   - `Shift + Close` – allow exit in kiosk mode
+3. **Logging**
+   - Log files stored under `%LOCALAPPDATA%\\MultiScreenKiosk\\logs`
+   - Per launch: `YYYYMMDD_N_Logfile.log`


### PR DESCRIPTION
## Summary
- Add German guide covering installation, configuration and operation
- Add English manual with equivalent instructions
- Clarify docs to download the release EXE instead of running via Python or PyInstaller

## Testing
- `PYTHONPATH=. pytest tests/test_config.py -q`
- `PYTHONPATH=. pytest tests/test_services.py -q` *(fails: ModuleNotFoundError: No module named 'services.browser_service')*


------
https://chatgpt.com/codex/tasks/task_e_68c7daa914088327a9547b2761a78770