### PR TITLE
Implement remote log export capability

### DIFF
--- a/kiosk_app/modules/services/browser_service.py
+++ b/kiosk_app/modules/services/browser_service.py
@@ -1,0 +1,3 @@
+"""Kompatibilitaetsmodul fuer historische Importe."""
+
+from .browser_services import *  # noqa: F401,F403

--- a/kiosk_app/modules/tests/__init__.py
+++ b/kiosk_app/modules/tests/__init__.py
@@ -1,0 +1,114 @@
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+base_str = str(BASE_DIR)
+if base_str not in sys.path:
+    sys.path.insert(0, base_str)
+
+import types
+
+
+def _install_qtcore_stub():
+    if "PySide6.QtCore" in sys.modules:
+        return sys.modules["PySide6.QtCore"]
+
+    qtcore = types.ModuleType("PySide6.QtCore")
+
+    class _DummySignal:
+        def __init__(self):
+            self._handler = None
+
+        def connect(self, handler):
+            self._handler = handler
+
+        def emit(self, *args, **kwargs):
+            if self._handler:
+                try:
+                    self._handler(*args, **kwargs)
+                except Exception:
+                    pass
+
+    def Signal(*_args, **_kwargs):  # type: ignore
+        return _DummySignal()
+
+    class QObject:  # type: ignore
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    class QTimer:  # type: ignore
+        def __init__(self, *_args, **_kwargs):
+            self.timeout = Signal()
+            self._interval = 0
+
+        def setInterval(self, value):
+            self._interval = value
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    class QUrl:  # type: ignore
+        def __init__(self, url: str):
+            self._url = url
+
+    qtcore.Signal = Signal
+    qtcore.QObject = QObject
+    qtcore.QTimer = QTimer
+    qtcore.QUrl = QUrl
+    qtcore.__package__ = "PySide6"
+    sys.modules["PySide6.QtCore"] = qtcore
+    return qtcore
+
+
+def _install_qtwe_stub():
+    if "PySide6.QtWebEngineWidgets" in sys.modules:
+        return sys.modules["PySide6.QtWebEngineWidgets"]
+
+    qtwe = types.ModuleType("PySide6.QtWebEngineWidgets")
+
+    class QWebEngineView:  # type: ignore
+        def __init__(self):
+            core = _install_qtcore_stub()
+            self.loadStarted = core.Signal()
+            self.loadFinished = core.Signal()
+            self._zoom = 1.0
+            self._url = None
+
+        def setZoomFactor(self, value):
+            self._zoom = value
+
+        def setUrl(self, url):
+            self._url = url
+
+        def reload(self):
+            pass
+
+    qtwe.QWebEngineView = QWebEngineView
+    qtwe.__package__ = "PySide6"
+    sys.modules["PySide6.QtWebEngineWidgets"] = qtwe
+    return qtwe
+
+
+try:
+    import PySide6  # type: ignore
+except Exception:  # pragma: no cover - provide stub for headless CI
+    stub_pkg = types.ModuleType("PySide6")
+    stub_pkg.__path__ = []  # type: ignore[attr-defined]
+    stub_pkg.__all__ = ["QtCore", "QtWebEngineWidgets"]
+    qtcore = _install_qtcore_stub()
+    qtwe = _install_qtwe_stub()
+    stub_pkg.QtCore = qtcore
+    stub_pkg.QtWebEngineWidgets = qtwe
+    sys.modules["PySide6"] = stub_pkg
+else:  # pragma: no cover - augment incomplete Qt installs
+    try:
+        from PySide6 import QtCore  # type: ignore
+    except Exception:
+        PySide6.QtCore = _install_qtcore_stub()  # type: ignore[attr-defined]
+    try:
+        from PySide6 import QtWebEngineWidgets  # type: ignore
+    except Exception:
+        PySide6.QtWebEngineWidgets = _install_qtwe_stub()  # type: ignore[attr-defined]

--- a/kiosk_app/modules/tests/test_config.py
+++ b/kiosk_app/modules/tests/test_config.py
@@ -40,3 +40,48 @@ def test_shortcuts_override(tmp_path: Path):
     cfg = load_config(p)
     assert cfg.ui.shortcuts["toggle_kiosk"] == "Ctrl+F"
     assert cfg.ui.shortcuts["select_1"] == DEFAULT_SHORTCUTS["select_1"]
+
+
+def test_remote_logging_settings(tmp_path: Path):
+    cfg_data = {
+        "sources": [{"type": "browser", "name": "A", "url": "http://example.com"}],
+        "logging": {
+            "remote_export": {
+                "enabled": True,
+                "include_history": 2,
+                "source_glob": "*.log",
+                "schedule_minutes": 15,
+                "destinations": [
+                    {
+                        "type": "http",
+                        "name": "api",
+                        "url": "https://example.com/upload",
+                        "headers": {"X-Test": "1"},
+                    },
+                    {
+                        "type": "email",
+                        "smtp_host": "smtp.example.com",
+                        "email_from": "kiosk@example.com",
+                        "email_to": ["ops@example.com"],
+                        "use_tls": True,
+                    },
+                ],
+            }
+        }
+    }
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(cfg_data))
+    cfg = load_config(p)
+    remote = cfg.logging.remote_export
+    assert remote.enabled is True
+    assert remote.include_history == 2
+    assert remote.source_glob == "*.log"
+    assert remote.schedule_minutes == 15
+    assert len(remote.destinations) == 2
+    http_dest = remote.destinations[0]
+    email_dest = remote.destinations[1]
+    assert http_dest.type == "http"
+    assert http_dest.url == "https://example.com/upload"
+    assert email_dest.type == "email"
+    assert email_dest.smtp_host == "smtp.example.com"
+    assert email_dest.email_to == ["ops@example.com"]

--- a/kiosk_app/modules/tests/test_remote_export.py
+++ b/kiosk_app/modules/tests/test_remote_export.py
@@ -1,0 +1,213 @@
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+from utils import remote_export as remote_export_module
+from utils.config_loader import RemoteLogDestination, RemoteLogExportSettings
+from utils.remote_export import RemoteLogExporter, RemoteExportResult
+
+
+def _create_log(tmp_path: Path) -> Path:
+    log_file = tmp_path / "20240101_1_kiosk.log"
+    log_file.write_text("2024-01-01 00:00:00 INFO bootstrap\n")
+    return log_file
+
+
+def test_remote_export_http_success(tmp_path, monkeypatch):
+    log_file = _create_log(tmp_path)
+    settings = RemoteLogExportSettings(
+        enabled=True,
+        include_history=1,
+        retention_count=3,
+        staging_dir=str(tmp_path / "exports"),
+        destinations=[
+            RemoteLogDestination(
+                type="http",
+                name="api",
+                url="https://example.com/upload",
+                method="POST",
+                headers={"X-Test": "1"},
+                verify_tls=False,
+            )
+        ],
+    )
+    exporter = RemoteLogExporter(settings, log_path=log_file)
+
+    called = {}
+
+    def fake_request(method, url, **kwargs):
+        called["method"] = method
+        called["url"] = url
+        called["files"] = kwargs.get("files")
+
+        class Response:
+            status_code = 200
+            text = "ok"
+
+        return Response()
+
+    monkeypatch.setattr(remote_export_module.requests, "request", fake_request)
+
+    result = exporter.export_now(reason="manual")
+
+    assert result.ok
+    assert called["url"] == "https://example.com/upload"
+    assert "file" in called["files"]
+    archives = list((tmp_path / "exports").glob("*.zip"))
+    assert len(archives) == 1
+
+
+def test_remote_export_sftp(monkeypatch, tmp_path):
+    log_file = _create_log(tmp_path)
+    uploads = {}
+
+    class DummyTransport:
+        def __init__(self, host_port):
+            uploads["host_port"] = host_port
+
+        def connect(self, username=None, password=None, pkey=None):
+            uploads["auth"] = {"username": username, "password": password, "pkey": pkey}
+
+        def close(self):
+            uploads["closed"] = True
+
+    class DummySFTP:
+        def put(self, local, remote):
+            uploads["put"] = (local, remote)
+
+        def close(self):
+            uploads["sftp_closed"] = True
+
+    dummy_sftp = DummySFTP()
+
+    class DummySFTPClient:
+        @staticmethod
+        def from_transport(transport):
+            uploads["transport"] = transport
+            return dummy_sftp
+
+    monkeypatch.setattr(
+        remote_export_module,
+        "paramiko",
+        SimpleNamespace(
+            Transport=lambda host_port: DummyTransport(host_port),
+            SFTPClient=DummySFTPClient,
+            RSAKey=None,
+            Ed25519Key=None,
+            ECDSAKey=None,
+        ),
+    )
+
+    settings = RemoteLogExportSettings(
+        enabled=True,
+        include_history=1,
+        retention_count=2,
+        destinations=[
+            RemoteLogDestination(
+                type="sftp",
+                name="sftp",
+                host="sftp.example.com",
+                username="user",
+                password="secret",
+                remote_path="/tmp/export.zip",
+            )
+        ],
+    )
+    exporter = RemoteLogExporter(settings, log_path=log_file)
+
+    result = exporter.export_now(reason="manual")
+
+    assert result.ok
+    assert uploads["host_port"] == ("sftp.example.com", 22)
+    assert uploads["auth"]["username"] == "user"
+    assert uploads["auth"]["password"] == "secret"
+    assert uploads["put"][1] == "/tmp/export.zip"
+
+
+def test_remote_export_email(monkeypatch, tmp_path):
+    log_file = _create_log(tmp_path)
+    sent = {}
+
+    class DummySMTP:
+        def __init__(self, host, port, timeout=None):
+            sent["init"] = {"host": host, "port": port, "timeout": timeout}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            sent["closed"] = True
+
+        def starttls(self):
+            sent["starttls"] = True
+
+        def login(self, username, password):
+            sent["login"] = (username, password)
+
+        def send_message(self, msg, from_addr, to_addrs):
+            sent["from"] = from_addr
+            sent["to"] = to_addrs
+            sent["message"] = msg
+
+    monkeypatch.setattr(remote_export_module.smtplib, "SMTP", DummySMTP)
+
+    settings = RemoteLogExportSettings(
+        enabled=True,
+        include_history=1,
+        destinations=[
+            RemoteLogDestination(
+                type="email",
+                name="mail",
+                email_from="kiosk@example.com",
+                email_to=["ops@example.com"],
+                smtp_host="smtp.example.com",
+                smtp_port=2525,
+                username="user",
+                password="secret",
+                use_tls=True,
+            )
+        ],
+    )
+    exporter = RemoteLogExporter(settings, log_path=log_file)
+
+    result = exporter.export_now(reason="manual")
+
+    assert result.ok
+    assert sent["init"]["host"] == "smtp.example.com"
+    assert sent["starttls"] is True
+    assert sent["login"] == ("user", "secret")
+    assert sent["to"] == ["ops@example.com"]
+    attachments = list(sent["message"].iter_attachments())
+    assert attachments
+    assert attachments[0].get_filename().endswith(".zip")
+
+
+def test_remote_export_schedule(monkeypatch, tmp_path):
+    log_file = _create_log(tmp_path)
+    settings = RemoteLogExportSettings(enabled=True, include_history=1, retention_count=1)
+    exporter = RemoteLogExporter(settings, log_path=log_file)
+
+    calls = []
+
+    def fake_export(reason="manual"):
+        calls.append(reason)
+        return RemoteExportResult(
+            archive=log_file,
+            files=[log_file],
+            successes=[],
+            failures={},
+            timestamp=datetime.now(timezone.utc),
+            reason=reason,
+            duration=0.0,
+        )
+
+    monkeypatch.setattr(exporter, "export_now", fake_export)
+
+    try:
+        exporter.start_periodic_export(interval_seconds=0.05)
+        time.sleep(0.12)
+    finally:
+        exporter.stop_periodic_export()
+
+    assert any(reason == "scheduled" for reason in calls)

--- a/kiosk_app/modules/utils/config_loader.py
+++ b/kiosk_app/modules/utils/config_loader.py
@@ -75,6 +75,51 @@ class KioskSettings:
 
 
 @dataclass
+class RemoteLogDestination:
+    type: str = "http"                       # "http", "sftp" oder "email"
+    name: str = ""                           # Anzeigename fuer UI / Logs
+    enabled: bool = True
+    url: Optional[str] = None                # HTTP Ziel
+    method: str = "POST"
+    headers: Dict[str, str] = field(default_factory=dict)
+    verify_tls: bool = True
+    timeout: int = 30
+    username: Optional[str] = None
+    password: Optional[str] = None
+    token: Optional[str] = None
+    host: Optional[str] = None               # fuer SFTP / SMTP
+    port: Optional[int] = None
+    remote_path: Optional[str] = None        # Zielpfad bei SFTP
+    private_key: Optional[str] = None
+    passphrase: Optional[str] = None
+    email_from: Optional[str] = None
+    email_to: List[str] = field(default_factory=list)
+    email_cc: List[str] = field(default_factory=list)
+    email_bcc: List[str] = field(default_factory=list)
+    smtp_host: Optional[str] = None
+    smtp_port: Optional[int] = None
+    use_tls: bool = True
+    use_ssl: bool = False
+    subject: str = "Kiosk Logs"
+    body: str = "Attached kiosk log export."
+    schedule_minutes: Optional[int] = None   # optionales Intervall pro Ziel
+
+
+@dataclass
+class RemoteLogExportSettings:
+    enabled: bool = False
+    destinations: List[RemoteLogDestination] = field(default_factory=list)
+    include_history: int = 3
+    compress: bool = True
+    staging_dir: Optional[str] = None
+    retention_days: Optional[int] = None
+    retention_count: Optional[int] = 10
+    source_glob: str = "*.log"
+    schedule_minutes: Optional[int] = None
+    notify_failures: bool = True
+
+
+@dataclass
 class LoggingSettings:
     level: str = "INFO"                      # DEBUG, INFO, WARNING, ERROR
     fmt: str = "plain"                       # "plain" oder "json"
@@ -84,7 +129,7 @@ class LoggingSettings:
     rotate_backups: int = 5
     console: bool = True
     qt_messages: bool = True
-    # Hinweis: weitere Felder aus deinem Logger koennen hier spaeter ergaenzt werden
+    remote_export: RemoteLogExportSettings = field(default_factory=RemoteLogExportSettings)
 
 
 @dataclass
@@ -106,6 +151,8 @@ __all__ = [
     "UISettings",
     "KioskSettings",
     "LoggingSettings",
+    "RemoteLogExportSettings",
+    "RemoteLogDestination",
     "UIConfig",
     "KioskConfig",
     "LoggingConfig",
@@ -142,6 +189,43 @@ def _as_int(d: Dict[str, Any], key: str, default: int) -> int:
         return int(d.get(key, default))
     except Exception:
         return default
+
+
+def _as_list(value: Any) -> List[str]:
+    """Normalisiert Listen- oder CSV-Eingaben zu einer Stringliste."""
+    items: List[str] = []
+    if value is None:
+        return items
+    if isinstance(value, (list, tuple, set)):
+        raw_iter = value
+    else:
+        raw_iter = [value]
+    for entry in raw_iter:
+        if entry is None:
+            continue
+        if isinstance(entry, str):
+            parts = entry.split(",")
+        else:
+            parts = [str(entry)]
+        for part in parts:
+            s = part.strip()
+            if s:
+                items.append(s)
+    return items
+
+
+def _opt_str(value: Any) -> Optional[str]:
+    s = _safe_str(value)
+    return s or None
+
+
+def _as_opt_int(value: Any) -> Optional[int]:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except Exception:
+        return None
 
 # =========================
 # Parser
@@ -275,6 +359,87 @@ def _parse_kiosk(data: Dict[str, Any]) -> KioskSettings:
     )
 
 
+def _parse_remote_destinations(raw: Dict[str, Any]) -> List[RemoteLogDestination]:
+    items = raw.get("destinations") if isinstance(raw, dict) else None
+    destinations: List[RemoteLogDestination] = []
+    if not isinstance(items, list):
+        return destinations
+
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        typ = (_safe_str(entry.get("type")) or "http").lower()
+        if typ not in {"http", "sftp", "email"}:
+            continue
+
+        name = _safe_str(entry.get("name") or "") or typ.upper()
+        headers_data = entry.get("headers")
+        headers: Dict[str, str] = {}
+        if isinstance(headers_data, dict):
+            for k, v in headers_data.items():
+                try:
+                    headers[str(k)] = _safe_str(v)
+                except Exception:
+                    continue
+
+        dest = RemoteLogDestination(
+            type=typ,
+            name=name,
+            enabled=_as_bool(entry, "enabled", True),
+            url=_opt_str(entry.get("url") or entry.get("endpoint")),
+            method=_safe_str(entry.get("method") or "POST").upper() if typ == "http" else _safe_str(entry.get("method") or "POST"),
+            headers=headers,
+            verify_tls=_as_bool(entry, "verify_tls", True),
+            timeout=_as_int(entry, "timeout", 30),
+            username=_opt_str(entry.get("username") or entry.get("user")),
+            password=_opt_str(entry.get("password")),
+            token=_opt_str(entry.get("token") or entry.get("bearer_token")),
+            host=_opt_str(entry.get("host") or entry.get("server")),
+            port=_as_opt_int(entry.get("port")),
+            remote_path=_opt_str(entry.get("remote_path") or entry.get("path")),
+            private_key=_opt_str(entry.get("private_key") or entry.get("key_file")),
+            passphrase=_opt_str(entry.get("passphrase") or entry.get("key_passphrase")),
+            email_from=_opt_str(entry.get("email_from") or entry.get("from")),
+            email_to=_as_list(entry.get("email_to") or entry.get("recipients")),
+            email_cc=_as_list(entry.get("email_cc")),
+            email_bcc=_as_list(entry.get("email_bcc")),
+            smtp_host=_opt_str(entry.get("smtp_host") or entry.get("host")),
+            smtp_port=_as_opt_int(entry.get("smtp_port") or entry.get("port")),
+            use_tls=_as_bool(entry, "use_tls", True),
+            use_ssl=_as_bool(entry, "use_ssl", False),
+            subject=_safe_str(entry.get("subject") or "Kiosk Logs"),
+            body=_safe_str(entry.get("body") or entry.get("message") or "Attached kiosk log export."),
+            schedule_minutes=_as_opt_int(entry.get("schedule_minutes")),
+        )
+        destinations.append(dest)
+
+    return destinations
+
+
+def _parse_remote_export(lg: Dict[str, Any]) -> RemoteLogExportSettings:
+    raw = lg.get("remote_export") or {}
+    if not isinstance(raw, dict):
+        raw = {}
+    retention_count_val = _as_opt_int(raw.get("retention_count"))
+    if retention_count_val is not None and retention_count_val < 0:
+        retention_count_val = None
+    retention_days_val = _as_opt_int(raw.get("retention_days"))
+    if retention_days_val is not None and retention_days_val < 0:
+        retention_days_val = None
+    return RemoteLogExportSettings(
+        enabled=_as_bool(raw, "enabled", False),
+        destinations=_parse_remote_destinations(raw),
+        include_history=_as_int(raw, "include_history", 3),
+        compress=_as_bool(raw, "compress", True),
+        staging_dir=_opt_str(raw.get("staging_dir")),
+        retention_days=retention_days_val,
+        retention_count=10 if retention_count_val is None else retention_count_val,
+        source_glob=_safe_str(raw.get("source_glob") or "*.log"),
+        schedule_minutes=_as_opt_int(raw.get("schedule_minutes")),
+        notify_failures=_as_bool(raw, "notify_failures", True),
+    )
+
+
 def _parse_logging(data: Dict[str, Any]) -> LoggingSettings:
     lg = data.get("logging") or {}
     return LoggingSettings(
@@ -286,6 +451,7 @@ def _parse_logging(data: Dict[str, Any]) -> LoggingSettings:
         rotate_backups=_as_int(lg, "rotate_backups", 5),
         console=_as_bool(lg, "console", True),
         qt_messages=_as_bool(lg, "qt_messages", True),
+        remote_export=_parse_remote_export(lg),
     )
 
 # =========================

--- a/kiosk_app/modules/utils/remote_export.py
+++ b/kiosk_app/modules/utils/remote_export.py
@@ -1,0 +1,353 @@
+# modules/utils/remote_export.py
+from __future__ import annotations
+
+import logging
+import os
+import smtplib
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional
+from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
+
+import requests
+
+from modules.utils.config_loader import RemoteLogDestination, RemoteLogExportSettings
+
+try:  # pragma: no cover - optional dependency
+    import paramiko  # type: ignore
+except Exception:  # pragma: no cover - resolved lazily in _send_sftp
+    paramiko = None  # type: ignore
+
+
+class RemoteExportError(RuntimeError):
+    """Fehler beim Remote Export."""
+
+
+@dataclass
+class RemoteExportResult:
+    archive: Path
+    files: List[Path]
+    successes: List[str]
+    failures: Dict[str, str]
+    timestamp: datetime
+    reason: str
+    duration: float
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures and bool(self.successes)
+
+
+class RemoteLogExporter:
+    """Exportiert Logfiles zu konfigurierten Remote Zielen."""
+
+    def __init__(
+        self,
+        settings: RemoteLogExportSettings,
+        log_path: str | os.PathLike[str],
+        logger: Optional[logging.Logger] = None,
+        notify: Optional[Callable[[str, bool, Optional[Exception]], None]] = None,
+    ) -> None:
+        self.settings = settings
+        self.log_path = Path(log_path).resolve()
+        self.log_dir = self.log_path.parent
+        self.logger = logger or logging.getLogger(__name__)
+        self.notify_callback = notify
+        self.export_dir = Path(settings.staging_dir or (self.log_dir / "exports"))
+        self.export_dir.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self.last_result: Optional[RemoteExportResult] = None
+
+    # ======== Public API ========
+
+    def export_now(self, reason: str = "manual") -> RemoteExportResult:
+        start = time.perf_counter()
+        with self._lock:
+            files = self._collect_files()
+            if not files:
+                raise RemoteExportError(
+                    f"no log files found in {self.log_dir} matching {self.settings.source_glob}"
+                )
+            archive = self._create_archive(files)
+            successes: List[str] = []
+            failures: Dict[str, str] = {}
+            for dest in self._destinations_for_cycle():
+                identifier = dest.name or dest.type
+                try:
+                    self._send_to_destination(dest, archive)
+                    successes.append(identifier)
+                    self._notify(f"Log export to {identifier} completed", True, None)
+                except Exception as ex:
+                    failures[identifier] = str(ex)
+                    self.logger.warning("log export to %s failed: %s", identifier, ex, extra={"source": "logging"})
+                    self._notify(f"Log export to {identifier} failed", False, ex)
+
+            self._apply_retention()
+
+            duration = time.perf_counter() - start
+            result = RemoteExportResult(
+                archive=archive,
+                files=files,
+                successes=successes,
+                failures=failures,
+                timestamp=datetime.now(timezone.utc),
+                reason=reason,
+                duration=duration,
+            )
+            self.last_result = result
+            return result
+
+    def start_periodic_export(
+        self,
+        interval_minutes: Optional[int] = None,
+        *,
+        interval_seconds: Optional[float] = None,
+    ) -> bool:
+        if interval_seconds is None:
+            minutes = interval_minutes
+            if minutes is None:
+                minutes = self.settings.schedule_minutes
+            if minutes is None:
+                return False
+            interval_seconds = float(minutes) * 60.0
+        if interval_seconds is None or interval_seconds <= 0:
+            return False
+
+        if self._thread and self._thread.is_alive():
+            return True
+
+        self._stop_event.clear()
+        thread = threading.Thread(
+            target=self._run_periodic,
+            args=(interval_seconds,),
+            name="RemoteLogExporter",
+            daemon=True,
+        )
+        self._thread = thread
+        thread.start()
+        return True
+
+    def stop_periodic_export(self, timeout: float = 5.0) -> None:
+        self._stop_event.set()
+        thread = self._thread
+        if thread and thread.is_alive():
+            thread.join(timeout=timeout)
+        self._thread = None
+
+    def shutdown(self) -> None:
+        self.stop_periodic_export()
+
+    # ======== Internals ========
+
+    def _run_periodic(self, interval_seconds: float) -> None:
+        while not self._stop_event.wait(interval_seconds):
+            try:
+                self.export_now(reason="scheduled")
+            except Exception as ex:  # pragma: no cover - safety log
+                self.logger.error("scheduled log export failed: %s", ex, extra={"source": "logging"})
+
+    def _destinations_for_cycle(self) -> Iterable[RemoteLogDestination]:
+        for dest in self.settings.destinations:
+            if not dest.enabled:
+                continue
+            yield dest
+
+    def _collect_files(self) -> List[Path]:
+        pattern = self.settings.source_glob or "*.log"
+        files = sorted(
+            (p for p in self.log_dir.glob(pattern) if p.is_file()),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        limit = self.settings.include_history
+        if limit is None or limit <= 0:
+            return files
+        return files[:limit]
+
+    def _create_archive(self, files: List[Path]) -> Path:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        archive_name = f"log_export_{timestamp}.zip"
+        archive_path = self.export_dir / archive_name
+        compression = ZIP_DEFLATED if self.settings.compress else ZIP_STORED
+        with ZipFile(archive_path, "w", compression=compression) as zf:
+            for file in files:
+                zf.write(file, arcname=file.name)
+        return archive_path
+
+    def _send_to_destination(self, dest: RemoteLogDestination, archive: Path) -> None:
+        if dest.type == "http":
+            self._send_http(dest, archive)
+        elif dest.type == "sftp":
+            self._send_sftp(dest, archive)
+        elif dest.type == "email":
+            self._send_email(dest, archive)
+        else:
+            raise RemoteExportError(f"unknown destination type: {dest.type}")
+
+    def _send_http(self, dest: RemoteLogDestination, archive: Path) -> None:
+        if not dest.url:
+            raise RemoteExportError("HTTP destination missing 'url'")
+        method = (dest.method or "POST").upper()
+        headers = dict(dest.headers)
+        if dest.token and not any(k.lower() == "authorization" for k in headers):
+            headers["Authorization"] = f"Bearer {dest.token}"
+        auth = None
+        if dest.username and dest.password:
+            from requests.auth import HTTPBasicAuth
+
+            auth = HTTPBasicAuth(dest.username, dest.password)
+        with archive.open("rb") as fh:
+            files = {"file": (archive.name, fh, "application/zip")}
+            response = requests.request(
+                method,
+                dest.url,
+                files=files,
+                headers=headers,
+                verify=dest.verify_tls,
+                timeout=dest.timeout or None,
+                auth=auth,
+            )
+            if response.status_code // 100 != 2:
+                snippet = (response.text or "")[:200]
+                raise RemoteExportError(f"HTTP upload failed with status {response.status_code}: {snippet}")
+
+    def _load_private_key(self, dest: RemoteLogDestination):
+        if not dest.private_key:
+            return None
+        if paramiko is None:
+            raise RemoteExportError("paramiko is required for private key authentication")
+        loaders = [
+            getattr(paramiko, name, None)
+            for name in ("RSAKey", "Ed25519Key", "ECDSAKey")
+        ]
+        last_error: Optional[Exception] = None
+        for loader in loaders:
+            if loader is None:
+                continue
+            try:
+                return loader.from_private_key_file(dest.private_key, password=dest.passphrase)
+            except Exception as ex:  # pragma: no cover - fallback order
+                last_error = ex
+                continue
+        if last_error:
+            raise RemoteExportError(f"could not load private key: {last_error}")
+        raise RemoteExportError("paramiko does not support private key loader")
+
+    def _send_sftp(self, dest: RemoteLogDestination, archive: Path) -> None:
+        if not dest.host:
+            raise RemoteExportError("SFTP destination missing 'host'")
+        if paramiko is None:
+            raise RemoteExportError("paramiko is required for SFTP uploads")
+        port = dest.port or 22
+        transport = paramiko.Transport((dest.host, port))
+        try:
+            pkey = self._load_private_key(dest)
+            if pkey is not None:
+                if not dest.username:
+                    raise RemoteExportError("SFTP private key authentication requires username")
+                transport.connect(username=dest.username, pkey=pkey)
+            else:
+                if not dest.username:
+                    raise RemoteExportError("SFTP destination requires username")
+                if not dest.password:
+                    raise RemoteExportError("SFTP password missing and no private key provided")
+                transport.connect(username=dest.username, password=dest.password)
+            sftp = paramiko.SFTPClient.from_transport(transport)
+            try:
+                remote_path = dest.remote_path or f"/tmp/{archive.name}"
+                sftp.put(str(archive), remote_path)
+            finally:
+                try:
+                    sftp.close()
+                except Exception:
+                    pass
+        finally:
+            try:
+                transport.close()
+            except Exception:
+                pass
+
+    def _send_email(self, dest: RemoteLogDestination, archive: Path) -> None:
+        recipients = dest.email_to + dest.email_cc + dest.email_bcc
+        if not recipients:
+            raise RemoteExportError("Email destination requires at least one recipient")
+        sender = dest.email_from or (dest.username or "")
+        if not sender:
+            raise RemoteExportError("Email destination requires 'email_from' or username")
+        host = dest.smtp_host or dest.host
+        if not host:
+            raise RemoteExportError("Email destination missing SMTP host")
+
+        port = dest.smtp_port or dest.port
+        if port is None:
+            port = 465 if dest.use_ssl else (587 if dest.use_tls else 25)
+
+        msg = EmailMessage()
+        msg["Subject"] = dest.subject or "Kiosk Logs"
+        msg["From"] = sender
+        msg["To"] = ", ".join(dest.email_to)
+        if dest.email_cc:
+            msg["Cc"] = ", ".join(dest.email_cc)
+        msg.set_content(dest.body or "Attached kiosk log export.")
+        with archive.open("rb") as fh:
+            data = fh.read()
+        msg.add_attachment(data, maintype="application", subtype="zip", filename=archive.name)
+
+        smtp_cls = smtplib.SMTP_SSL if dest.use_ssl else smtplib.SMTP
+        with smtp_cls(host, port, timeout=dest.timeout or None) as smtp:
+            if dest.use_tls and not dest.use_ssl:
+                smtp.starttls()
+            if dest.username:
+                smtp.login(dest.username, dest.password or "")
+            smtp.send_message(msg, from_addr=sender, to_addrs=recipients)
+
+    def _apply_retention(self) -> None:
+        retention_count = self.settings.retention_count
+        if retention_count is not None and retention_count < 0:
+            retention_count = None
+        retention_days = self.settings.retention_days
+        if retention_days is not None and retention_days < 0:
+            retention_days = None
+
+        if retention_count is None and retention_days is None:
+            return
+
+        archives = sorted(
+            (p for p in self.export_dir.glob("log_export_*.zip") if p.is_file()),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        now = datetime.now(timezone.utc)
+        for idx, archive in enumerate(archives):
+            remove = False
+            if retention_count is not None and idx >= retention_count:
+                remove = True
+            if not remove and retention_days is not None:
+                age = now - datetime.utcfromtimestamp(archive.stat().st_mtime)
+                if age > timedelta(days=retention_days):
+                    remove = True
+            if remove:
+                try:
+                    archive.unlink()
+                except FileNotFoundError:
+                    pass
+
+    def _notify(self, message: str, success: bool, error: Optional[Exception]) -> None:
+        if not self.notify_callback:
+            return
+        if not success and not self.settings.notify_failures:
+            return
+        try:
+            self.notify_callback(message, success, error)
+        except Exception:
+            self.logger.debug("notification callback failed", exc_info=True)
+
+
+import smtplib  # noqa: E402  # isort:skip (after smtplib usage)
+


### PR DESCRIPTION
## Summary
- add remote log export configuration support and parsing helpers
- implement a remote log exporter with HTTP, SFTP, and email destinations plus scheduling and retention
- expose remote export controls through the logging module and cover the feature with automated tests and compatibility shims

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c91e6bfa408327a9700acabe0b2688