### PR TITLE
Redesign kiosk UI with modern theme and navigation

### DIFF
--- a/kiosk_app/modules/ui/browser_host.py
+++ b/kiosk_app/modules/ui/browser_host.py
@@ -21,6 +21,7 @@ class BrowserHostWidget(QWidget):
         self.stack.setSpacing(0)
 
         self.placeholder = QLabel("", self)
+        self.placeholder.setObjectName("BrowserPlaceholder")
         self.placeholder.setAlignment(Qt.AlignCenter)
 
         self.movie: Optional[QMovie] = None

--- a/kiosk_app/modules/ui/log_viewer.py
+++ b/kiosk_app/modules/ui/log_viewer.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import (
     QCheckBox, QPushButton, QTextEdit, QFileDialog, QMessageBox, QWidget
 )
 
+from modules.ui.theme import get_palette, build_dialog_stylesheet
 from modules.utils.logger import get_log_path, get_log_bridge
 from modules.utils.i18n import tr, i18n
 
@@ -32,12 +33,15 @@ def _human_size(n: int) -> str:
 class LogStatsDialog(QDialog):
     """Live Log Statistik mit Dateigroesse und Level Zaehlern."""
 
-    def __init__(self, log_path: str, parent: Optional[QWidget] = None):
+    def __init__(self, log_path: str, theme: str | None = None, parent: Optional[QWidget] = None):
         super().__init__(parent)
         self._path = log_path
         self.setWindowTitle(tr("Log Statistics"))
         self.setModal(False)
         self.setMinimumSize(520, 360)
+
+        palette = get_palette(theme)
+        self.setStyleSheet(build_dialog_stylesheet(palette))
 
         layout = QVBoxLayout(self)
         self.lbl_info = QLabel(self)
@@ -50,6 +54,7 @@ class LogStatsDialog(QDialog):
         btns = QHBoxLayout()
         btns.addStretch(1)
         self.btn_close = QPushButton(tr("Close"), self)
+        self.btn_close.setProperty("accent", True)
         self.btn_close.clicked.connect(self.close)
         btns.addWidget(self.btn_close)
         layout.addLayout(btns)
@@ -119,11 +124,15 @@ class LogStatsDialog(QDialog):
 
 class LogViewer(QDialog):
     """Einfacher Log Viewer mit Filtern und Live Update."""
-    def __init__(self, parent=None):
+    def __init__(self, parent: Optional[QWidget] = None, theme: str | None = None):
         super().__init__(parent)
         self.setWindowTitle(tr("Logs"))
         self.setModal(False)
         self.setMinimumSize(800, 480)
+
+        self._theme = theme or "light"
+        self._palette = get_palette(self._theme)
+        self.setStyleSheet(build_dialog_stylesheet(self._palette))
 
         self._path = get_log_path()
         self._buffer: List[str] = []   # Rohzeilen fuer Refilter
@@ -358,7 +367,7 @@ class LogViewer(QDialog):
         self.btn_stats.setText(tr("Log Statistics"))
 
     def _open_stats_window(self):
-        dlg = LogStatsDialog(self._path, self)
+        dlg = LogStatsDialog(self._path, self._theme, self)
         dlg.setModal(False)
         dlg.setAttribute(Qt.WA_DeleteOnClose, True)
         dlg.show()

--- a/kiosk_app/modules/ui/setup_dialog.py
+++ b/kiosk_app/modules/ui/setup_dialog.py
@@ -11,6 +11,8 @@ from PySide6.QtWidgets import (
     QSpinBox, QGridLayout
 )
 
+from modules.ui.theme import get_palette, build_dialog_stylesheet
+
 
 # ---------- Hilfs Widgets ----------
 
@@ -257,25 +259,8 @@ class SetupDialog(QDialog):
         return "light"
 
     def apply_theme(self, theme: str):
-        """Einfaches hell/dunkel Styling, analog zur Hauptapp."""
-        if str(theme).lower() == "dark":
-            self.setStyleSheet("""
-                QWidget { background: #121212; color: #e0e0e0; }
-                QLineEdit, QComboBox { background: #1b1b1b; border: 1px solid #2a2a2a; padding: 6px 8px; border-radius: 8px; }
-                QCheckBox::indicator { width: 16px; height: 16px; border: 1px solid #5a5a5a; background: #2a2a2a; }
-                QCheckBox::indicator:checked { background: #3b82f6; border: 1px solid #3b82f6; }
-                QPushButton { background: #1f1f1f; border: 1px solid #2a2a2a; padding: 8px 12px; border-radius: 10px; }
-                QPushButton:hover { border-color: #3a3a3a; }
-            """)
-        else:
-            self.setStyleSheet("""
-                QWidget { background: #f4f4f4; color: #202020; }
-                QLineEdit, QComboBox { background: #ffffff; border: 1px solid #d0d0d0; padding: 6px 8px; border-radius: 8px; }
-                QCheckBox::indicator { width: 16px; height: 16px; border: 1px solid #999; background: #fff; }
-                QCheckBox::indicator:checked { background: #0078d4; border: 1px solid #0078d4; }
-                QPushButton { background: #ffffff; border: 1px solid #d0d0d0; padding: 8px 12px; border-radius: 10px; }
-                QPushButton:hover { border-color: #bcbcbc; }
-            """)
+        palette = get_palette(theme)
+        self.setStyleSheet(build_dialog_stylesheet(palette))
 
     # -------- Layout Zeilen --------
 

--- a/kiosk_app/modules/ui/sidebar.py
+++ b/kiosk_app/modules/ui/sidebar.py
@@ -1,410 +1,401 @@
+from __future__ import annotations
+
 from typing import List, Optional
 
-from PySide6.QtCore import QSize, Qt, QRectF, Signal
-from PySide6.QtGui import QPixmap, QPainter, QTransform
+from PySide6.QtCore import Qt, QSize, Signal
+from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QToolButton, QPushButton,
-    QFrame, QSizePolicy, QMenu
+    QAbstractItemView,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QMenu,
+    QPushButton,
+    QSizePolicy,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+    QStyle,
 )
 
+from modules.ui.theme import ThemePalette
 from modules.utils.i18n import tr, i18n
 
 
-class RotatableLogoWidget(QWidget):
-    """Logo Widget. Dreht das Bild bei Ausrichtung 'left' um 90 Grad.
-    Skaliert proportional mit Antialiasing fuer gute Lesbarkeit."""
-    def __init__(self, path: str = "", orientation: str = "left", parent: Optional[QWidget] = None):
-        super().__init__(parent)
-        self._pix: Optional[QPixmap] = None
-        self._orientation = orientation  # "left" oder "top"
-        self.set_logo(path)
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+class Sidebar(QFrame):
+    """Modern navigation rail with paging support."""
 
-    def set_logo(self, path: str):
-        self._pix = QPixmap(path) if path else None
-        self.updateGeometry()
-        self.update()
-
-    def set_orientation(self, orientation: str):
-        self._orientation = orientation
-        self.updateGeometry()
-        self.update()
-
-    def sizeHint(self) -> QSize:
-        if self._orientation == "top":
-            h = 24
-            if self._pix and not self._pix.isNull():
-                ar = self._pix.width() / max(1, self._pix.height())
-                return QSize(int(h * ar), h)
-            return QSize(96, h)
-        else:
-            w = 48
-            if self._pix and not self._pix.isNull():
-                ar = self._pix.height() / max(1, self._pix.width())  # wegen Rotation
-                return QSize(w, int(max(120, w * ar)))
-            return QSize(w, 140)
-
-    def minimumSizeHint(self) -> QSize:
-        return QSize(24, 24)
-
-    def paintEvent(self, ev):
-        super().paintEvent(ev)
-        if not self._pix or self._pix.isNull():
-            return
-        p = QPainter(self)
-        p.setRenderHint(QPainter.SmoothPixmapTransform, True)
-        rect = self.rect()
-
-        pix = self._pix
-        if self._orientation == "left":
-            tr = QTransform()
-            tr.rotate(-90)
-            pix = self._pix.transformed(tr, Qt.SmoothTransformation)
-
-        margin = 6
-        target = QRectF(rect.adjusted(margin, margin, -margin, -margin))
-        pr = pix.rect()
-        pr_ar = pr.width() / max(1, pr.height())
-        tr_ar = target.width() / max(1.0, target.height())
-
-        if pr_ar > tr_ar:
-            w = target.width()
-            h = w / pr_ar
-            x = target.left()
-            y = target.top() + (target.height() - h) / 2
-        else:
-            h = target.height()
-            w = h * pr_ar
-            x = target.left() + (target.width() - w) / 2
-            y = target.top()
-        p.drawPixmap(QRectF(x, y, w, h), pix, pix.rect())
-        p.end()
-
-
-class Sidebar(QWidget):
-    view_selected = Signal(int)       # globaler Index
+    view_selected = Signal(int)
     toggle_mode = Signal()
     page_changed = Signal(int)
     request_settings = Signal()
-    collapsed_changed = Signal(bool)  # true = eingeklappt
+    collapsed_changed = Signal(bool)
 
-    def __init__(self, titles: List[str], width: int = 96, orientation: str = "left",
-                 enable_hamburger: bool = True, logo_path: str = "", split_enabled: bool = True, parent=None):
+    def __init__(
+        self,
+        titles: List[str],
+        width: int = 96,
+        orientation: str = "left",
+        enable_hamburger: bool = True,
+        logo_path: str = "",
+        split_enabled: bool = True,
+        parent: Optional[QWidget] = None,
+    ) -> None:
         super().__init__(parent)
-        self._orientation = orientation  # "left" oder "top"
+        self.setObjectName("NavigationPanel")
+
+        self._orientation = orientation if orientation in {"left", "top"} else "left"
         self._all_titles = titles[:]
-        self._thickness = max(64, width)
+        self._thickness = max(72, width)
         self._page = 0
         self._page_size = 4
         self._collapsed = False
         self._enable_hamburger = enable_hamburger
         self._logo_path = logo_path
         self._split_enabled = split_enabled
+        self._palette: Optional[ThemePalette] = None
+        self._active_index = 0
+        self._suppress_selection_signal = False
 
-        self.setObjectName("Sidebar")
         self._build_ui()
-        self._refresh_page_buttons()
+        self.set_titles(self._all_titles)
+        self._apply_thickness()
+
         i18n.language_changed.connect(lambda _l: self.retranslate_ui())
         self.retranslate_ui()
 
-    # ---------- interne Helfer ----------
-    def _divider(self):
-        div = QFrame(self)
-        div.setFrameShape(QFrame.HLine if self._orientation == "top" else QFrame.VLine)
-        div.setFrameShadow(QFrame.Sunken)
-        return div
+    # ------------------------------------------------------------------ UI
+    def _clear_layout(self) -> None:
+        layout = self.layout()
+        if not layout:
+            return
+        while layout.count():
+            item = layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.setParent(None)
+        layout.deleteLater()
 
-    def _apply_thickness(self):
-        """Links feste Breite, Top dynamische Hoehe anhand sizeHint."""
-        if self._orientation == "top":
-            if self._collapsed:
-                h = 40
-            else:
-                h = max(40, self.sizeHint().height())
-            self.setFixedHeight(h)
-        else:
-            self.setFixedWidth(48 if self._collapsed else self._thickness)
+    def _build_ui(self) -> None:
+        self._clear_layout()
 
-    # ---------- Aufbau ----------
-    def _build_ui(self):
-        if self._orientation == "top":
-            self._build_top_ui()
-        else:
-            self._build_left_ui()
-        self._apply_thickness()
+        self.setProperty("orientation", self._orientation)
 
-    def _build_top_ui(self):
+        margins = (18, 24, 18, 18) if self._orientation == "left" else (24, 16, 24, 12)
+        spacing = 18 if self._orientation == "left" else 12
+
         root = QVBoxLayout(self)
-        root.setSpacing(6)
-        root.setContentsMargins(8, 8, 8, 8)
+        root.setContentsMargins(*margins)
+        root.setSpacing(spacing)
 
-        # Zeile 1: Burger | Logo | Stretch | Settings
         header = QHBoxLayout()
-        header.setSpacing(6)
+        header.setContentsMargins(0, 0, 0, 0)
+        header.setSpacing(12)
 
         self.btn_burger = QToolButton(self)
-        self.btn_burger.setText("☰")
-        self.btn_burger.setToolTip("")
+        self.btn_burger.setObjectName("NavBurger")
+        self.btn_burger.setIcon(self.style().standardIcon(QStyle.SP_TitleBarMenuButton))
+        self.btn_burger.setIconSize(QSize(18, 18))
         self.btn_burger.clicked.connect(self._on_burger_click)
         self.btn_burger.setVisible(self._enable_hamburger)
         header.addWidget(self.btn_burger)
 
-        self.logo = RotatableLogoWidget(self._logo_path, "top", self)
-        self.logo.setFixedHeight(24)
-        header.addWidget(self.logo)
+        self.logo_label = QLabel(self)
+        self.logo_label.setObjectName("NavLogo")
+        self.logo_label.setAlignment(Qt.AlignCenter)
+        self.logo_label.setFixedSize(QSize(48, 48))
+        header.addWidget(self.logo_label, 0)
 
-        header.addStretch(1)
+        text_box = QVBoxLayout()
+        text_box.setContentsMargins(0, 0, 0, 0)
+        text_box.setSpacing(4)
 
-        self.btn_settings = QToolButton(self)
-        self.btn_settings.setText("⚙")
-        self.btn_settings.setToolTip("")
-        self.btn_settings.clicked.connect(self.request_settings.emit)
-        header.addWidget(self.btn_settings)
+        self.caption_label = QLabel("", self)
+        self.caption_label.setObjectName("NavCaption")
+        text_box.addWidget(self.caption_label)
 
+        self.subtitle_label = QLabel("", self)
+        self.subtitle_label.setObjectName("NavSubtitle")
+        self.subtitle_label.setWordWrap(True)
+        text_box.addWidget(self.subtitle_label)
+
+        header.addLayout(text_box, 1)
         root.addLayout(header)
 
-        root.addWidget(self._divider())
+        self.list_widget = QListWidget(self)
+        self.list_widget.setObjectName("NavigationList")
+        self.list_widget.setFrameShape(QFrame.NoFrame)
+        self.list_widget.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
+        self.list_widget.setVerticalScrollMode(QAbstractItemView.ScrollPerPixel)
+        self.list_widget.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.list_widget.itemClicked.connect(self._on_item_clicked)
+        root.addWidget(self.list_widget, 1)
 
-        # Zeile 2: Prev | Buttons (breit) | Next
-        row_buttons = QHBoxLayout()
-        row_buttons.setSpacing(6)
+        self.empty_label = QLabel("", self)
+        self.empty_label.setObjectName("NavEmpty")
+        self.empty_label.setAlignment(Qt.AlignCenter)
+        root.addWidget(self.empty_label, 1)
 
-        self.btn_prev = QToolButton(self)
-        self.btn_prev.setText("◀")
+        self.page_widget = QWidget(self)
+        page_layout = QHBoxLayout(self.page_widget)
+        page_layout.setContentsMargins(0, 0, 0, 0)
+        page_layout.setSpacing(8)
+
+        self.btn_prev = QToolButton(self.page_widget)
+        self.btn_prev.setObjectName("PageButton")
+        self.btn_prev.setIcon(self.style().standardIcon(QStyle.SP_ArrowBack))
         self.btn_prev.clicked.connect(self.prev_page)
-        row_buttons.addWidget(self.btn_prev)
+        page_layout.addWidget(self.btn_prev)
 
-        self.buttons_wrap = QWidget(self)
-        self.buttons_layout = QHBoxLayout(self.buttons_wrap)
-        self.buttons_layout.setSpacing(6)
-        self.buttons_layout.setContentsMargins(0, 0, 0, 0)
+        self.page_label = QLabel("", self.page_widget)
+        self.page_label.setAlignment(Qt.AlignCenter)
+        page_layout.addWidget(self.page_label, 1)
 
-        self.buttons: List[QToolButton] = []
-        for i in range(self._page_size):
-            btn = QToolButton(self.buttons_wrap)
-            btn.setText("")
-            btn.setCheckable(True)
-            btn.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)  # gleichmaessige Breite
-            btn.clicked.connect(lambda checked, pos=i: self._emit_by_pos(pos))
-            self.buttons.append(btn)
-            self.buttons_layout.addWidget(btn, 1)  # Stretch=1 fuer gleiches Verteilen
-        row_buttons.addWidget(self.buttons_wrap, 1)
-
-        self.btn_next = QToolButton(self)
-        self.btn_next.setText("▶")
+        self.btn_next = QToolButton(self.page_widget)
+        self.btn_next.setObjectName("PageButton")
+        self.btn_next.setIcon(self.style().standardIcon(QStyle.SP_ArrowForward))
         self.btn_next.clicked.connect(self.next_page)
-        row_buttons.addWidget(self.btn_next)
+        page_layout.addWidget(self.btn_next)
 
-        root.addLayout(row_buttons)
+        root.addWidget(self.page_widget)
 
-        # Zeile 3: Switch vollbreit
+        bottom = QVBoxLayout()
+        bottom.setContentsMargins(0, 0, 0, 0)
+        bottom.setSpacing(10)
+
         self.btn_toggle = QPushButton("", self)
-        self.btn_toggle.setToolTip("Strg+Q")
-        self.btn_toggle.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.btn_toggle.setProperty("accent", True)
         self.btn_toggle.clicked.connect(self.toggle_mode.emit)
-        root.addWidget(self.btn_toggle)
         self.btn_toggle.setVisible(self._split_enabled)
+        bottom.addWidget(self.btn_toggle)
 
-        self._layout = root
-
-    def _build_left_ui(self):
-        layout = QVBoxLayout(self)
-        layout.setSpacing(8)
-        layout.setContentsMargins(8, 8, 8, 8)
-
-        # Kopfzeile
-        header = QHBoxLayout()
-        header.setSpacing(6)
-
-        self.btn_burger = QToolButton(self)
-        self.btn_burger.setText("☰")
-        self.btn_burger.setToolTip("")
-        self.btn_burger.clicked.connect(self._on_burger_click)
-        self.btn_burger.setVisible(self._enable_hamburger)
-        header.addWidget(self.btn_burger)
-
-        header.addStretch(1)
-
-        self.btn_settings = QToolButton(self)
-        self.btn_settings.setText("⚙")
-        self.btn_settings.setToolTip("")
+        self.btn_settings = QPushButton("", self)
         self.btn_settings.clicked.connect(self.request_settings.emit)
-        header.addWidget(self.btn_settings)
+        bottom.addWidget(self.btn_settings)
 
-        layout.addLayout(header)
+        root.addLayout(bottom)
 
-        # Pager
-        pager = QHBoxLayout()
-        pager.setSpacing(4)
-        self.btn_prev = QToolButton(self)
-        self.btn_prev.setText("◀")
-        self.btn_prev.clicked.connect(self.prev_page)
-        self.btn_next = QToolButton(self)
-        self.btn_next.setText("▶")
-        self.btn_next.clicked.connect(self.next_page)
-        pager.addWidget(self.btn_prev)
-        pager.addStretch(1)
-        pager.addWidget(self.btn_next)
-        layout.addLayout(pager)
+        self._apply_orientation_rules()
+        self._update_logo()
+        self._update_empty_state()
 
-        # Buttons oberhalb Logo
-        layout.addWidget(self._divider())
+    def _apply_orientation_rules(self) -> None:
+        if self._orientation == "top":
+            self.list_widget.setFlow(QListWidget.LeftToRight)
+            self.list_widget.setWrapping(True)
+            self.list_widget.setSpacing(6)
+            self.list_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+            self.list_widget.setFixedHeight(110)
+        else:
+            self.list_widget.setFlow(QListWidget.TopToBottom)
+            self.list_widget.setWrapping(False)
+            self.list_widget.setSpacing(2)
+            self.list_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+            self.list_widget.setMaximumHeight(16777215)
 
-        self.buttons_wrap = QWidget(self)
-        self.buttons_layout = QVBoxLayout(self.buttons_wrap)
-        self.buttons_layout.setSpacing(8)
-        self.buttons_layout.setContentsMargins(0, 0, 0, 0)
+    # ---------------------------------------------------------------- config
+    def set_titles(self, titles: List[str]) -> None:
+        self._all_titles = titles[:]
+        self._page = min(self._page, max(0, self.page_count() - 1))
 
-        self.buttons: List[QToolButton] = []
-        for i in range(self._page_size):
-            btn = QToolButton(self.buttons_wrap)
-            btn.setText("")                 # nur Name
-            btn.setCheckable(True)
-            btn.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-            btn.clicked.connect(lambda checked, pos=i: self._emit_by_pos(pos))
-            self.buttons.append(btn)
-            self.buttons_layout.addWidget(btn)
-        layout.addWidget(self.buttons_wrap)
+        self._suppress_selection_signal = True
+        try:
+            self.list_widget.clear()
+            for title in self._all_titles:
+                item = QListWidgetItem(title)
+                item.setSizeHint(QSize(-1, 46))
+                self.list_widget.addItem(item)
+        finally:
+            self._suppress_selection_signal = False
 
-        self.btn_toggle = QPushButton("", self)
-        self.btn_toggle.setToolTip("Strg+Q")
-        self.btn_toggle.clicked.connect(self.toggle_mode.emit)
-        layout.addWidget(self.btn_toggle)
-        self.btn_toggle.setVisible(self._split_enabled)
+        if self._all_titles:
+            target = min(self._active_index, len(self._all_titles) - 1)
+            self.set_active_global_index(max(0, target))
+        else:
+            self._active_index = 0
+            self._page = 0
+            self.list_widget.clearSelection()
 
-        # Freie Flaeche mit grossem Logo
-        layout.addStretch(1)
-        self.logo = RotatableLogoWidget(self._logo_path, "left", self)
-        self.logo.setMinimumHeight(140)
-        layout.addWidget(self.logo, 0, Qt.AlignHCenter)
-        layout.addStretch(1)
+        self._update_logo()
+        self._update_page_controls()
+        self._update_empty_state()
 
-        self._layout = layout
-
-    # ---------- Burger Logik ----------
-    def _on_burger_click(self):
-        new_state = not self._collapsed
-        self.set_collapsed(new_state)
-        self.collapsed_changed.emit(new_state)
-        if new_state:
-            m = QMenu(self)
-            for idx, title in enumerate(self._all_titles):
-                act = m.addAction(title)
-                act.triggered.connect(lambda _=False, i=idx: self.view_selected.emit(i))
-            m.addSeparator()
-            act_settings = m.addAction(tr("Settings"))
-            act_settings.triggered.connect(self.request_settings.emit)
-            m.exec(self.mapToGlobal(self.btn_burger.geometry().bottomLeft()))
-
-    def set_collapsed(self, collapsed: bool):
-        self._collapsed = collapsed
-        # Sichtbarkeit aller variablen Teile
-        self.buttons_wrap.setVisible(not collapsed)
-        self.btn_prev.setVisible(not collapsed)
-        self.btn_next.setVisible(not collapsed)
-        self.btn_toggle.setVisible(self._split_enabled and not collapsed)
-        if hasattr(self, "logo"):
-            self.logo.setVisible(not collapsed)
+    def set_orientation(self, orientation: str) -> None:
+        orientation = orientation if orientation in {"left", "top"} else "left"
+        if orientation == self._orientation:
+            return
+        current = self._active_index
+        was_collapsed = self._collapsed
+        self._orientation = orientation
+        self._build_ui()
+        self.set_titles(self._all_titles)
+        self.set_active_global_index(current)
+        self.set_collapsed(was_collapsed)
         self._apply_thickness()
-        self.updateGeometry()
 
-    def set_hamburger_enabled(self, enabled: bool):
+    def set_hamburger_enabled(self, enabled: bool) -> None:
         self._enable_hamburger = enabled
-        self.btn_burger.setVisible(enabled)
+        if hasattr(self, "btn_burger"):
+            self.btn_burger.setVisible(enabled)
         if not enabled and self._collapsed:
             self.set_collapsed(False)
             self.collapsed_changed.emit(False)
 
-    def set_logo(self, path: str):
+    def set_logo(self, path: str) -> None:
         self._logo_path = path
-        if hasattr(self, "logo"):
-            self.logo.set_logo(path)
-        self.updateGeometry()
+        self._update_logo()
 
-    # ---------- Paging ----------
-    def _page_count(self) -> int:
-        return max(1, (len(self._all_titles) + self._page_size - 1) // self._page_size)
+    def apply_palette(self, palette: ThemePalette) -> None:
+        self._palette = palette
+        self._update_logo()
+        self._update_empty_state()
 
-    def _refresh_page_buttons(self):
-        start = self._page * self._page_size
-        for i, btn in enumerate(self.buttons):
-            idx = start + i
-            if idx < len(self._all_titles):
-                btn.setText(self._all_titles[idx])
-                btn.setEnabled(True)
+    # ---------------------------------------------------------------- state
+    def page_count(self) -> int:
+        if not self._all_titles:
+            return 1
+        return (len(self._all_titles) + self._page_size - 1) // self._page_size
+
+    def set_active_global_index(self, idx: int) -> None:
+        if idx < 0 or idx >= len(self._all_titles):
+            self._active_index = max(0, min(len(self._all_titles) - 1, idx))
+        else:
+            self._active_index = idx
+
+        target_page = 0 if len(self._all_titles) == 0 else self._active_index // self._page_size
+        if target_page != self._page:
+            self._page = target_page
+            self._update_page_controls()
+
+        self._suppress_selection_signal = True
+        try:
+            if 0 <= self._active_index < self.list_widget.count():
+                self.list_widget.setCurrentRow(self._active_index)
+                item = self.list_widget.item(self._active_index)
+                if item:
+                    self.list_widget.scrollToItem(item, QAbstractItemView.PositionAtCenter)
             else:
-                btn.setText("-")
-                btn.setEnabled(False)
-        if hasattr(self, "btn_prev"):
-            self.btn_prev.setEnabled(self._page > 0)
-        if hasattr(self, "btn_next"):
-            self.btn_next.setEnabled(self._page < self._page_count() - 1)
-        self._clear_checks()
-        self._apply_thickness()  # Top Hoehe ggf. neu berechnen
+                self.list_widget.clearSelection()
+        finally:
+            self._suppress_selection_signal = False
 
-    def _clear_checks(self):
-        for b in self.buttons:
-            b.setChecked(False)
+        self._update_page_controls()
+        self._update_empty_state()
 
-    def _emit_by_pos(self, pos: int):
-        if self._collapsed:
+    def next_page(self) -> None:
+        if self._page >= self.page_count() - 1:
             return
-        idx = self._page * self._page_size + pos
-        if idx < len(self._all_titles):
-            self.view_selected.emit(idx)
-            self._clear_checks()
-            self.buttons[pos].setChecked(True)
+        self._page += 1
+        start = self._page * self._page_size
+        if start < len(self._all_titles):
+            self.set_active_global_index(start)
+            self.view_selected.emit(start)
+        self._update_page_controls()
+        self.page_changed.emit(self._page)
 
-    def next_page(self):
-        if self._page < self._page_count() - 1:
-            self._page += 1
-            self._refresh_page_buttons()
-            self.page_changed.emit(self._page)
+    def prev_page(self) -> None:
+        if self._page <= 0:
+            return
+        self._page -= 1
+        start = self._page * self._page_size
+        if start < len(self._all_titles):
+            self.set_active_global_index(start)
+            self.view_selected.emit(start)
+        self._update_page_controls()
+        self.page_changed.emit(self._page)
 
-    def prev_page(self):
-        if self._page > 0:
-            self._page -= 1
-            self._refresh_page_buttons()
-            self.page_changed.emit(self._page)
-
-    # ---------- API ----------
-    def set_active_global_index(self, idx: int):
-        page = idx // self._page_size
-        if page != self._page:
-            self._page = page
-            self._refresh_page_buttons()
-        pos = idx % self._page_size
-        if 0 <= pos < len(self.buttons) and not self._collapsed:
-            self._clear_checks()
-            self.buttons[pos].setChecked(True)
-
-    def set_titles(self, titles: List[str]):
-        self._all_titles = titles[:]
-        self._page = 0
-        self._refresh_page_buttons()
-
-    def set_orientation(self, orientation: str):
-        # Layout komplett neu aufbauen, da Top und Left stark abweichen
-        self._orientation = orientation
-        # alles loeschen
-        while self.layout() and self.layout().count():
-            it = self.layout().takeAt(0)
-            w = it.widget()
-            if w:
-                w.setParent(None)
-        if self.layout():
-            self.layout().deleteLater()
-
-        # neu bauen
-        self._build_ui()
-        # Titel wieder setzen
-        self.set_titles(self._all_titles)
+    def set_collapsed(self, collapsed: bool) -> None:
+        self._collapsed = collapsed
+        self.btn_toggle.setVisible(self._split_enabled and not collapsed)
+        self.list_widget.setVisible(not collapsed and bool(self._all_titles))
+        self.empty_label.setVisible(not collapsed and not self._all_titles)
+        self.page_widget.setVisible(not collapsed and self.page_count() > 1)
+        self.btn_settings.setVisible(not collapsed)
+        self._apply_thickness()
         self.updateGeometry()
+        self._update_page_controls()
+        self._update_empty_state()
 
-    def retranslate_ui(self):
-        if hasattr(self, 'btn_burger'):
-            self.btn_burger.setToolTip(tr('Menu'))
-        if hasattr(self, 'btn_settings'):
-            self.btn_settings.setToolTip(tr('Settings'))
-        if hasattr(self, 'btn_toggle'):
-            self.btn_toggle.setText(tr('Switch'))
+    # ---------------------------------------------------------------- events
+    def _on_burger_click(self) -> None:
+        new_state = not self._collapsed
+        self.set_collapsed(new_state)
+        self.collapsed_changed.emit(new_state)
+        if new_state:
+            self._open_overlay_menu()
+
+    def _open_overlay_menu(self) -> None:
+        menu = QMenu(self)
+        for idx, title in enumerate(self._all_titles):
+            act = menu.addAction(title)
+            act.triggered.connect(lambda _=False, i=idx: self.view_selected.emit(i))
+        if self._all_titles:
+            menu.addSeparator()
+        act_settings = menu.addAction(tr("Settings"))
+        act_settings.triggered.connect(self.request_settings.emit)
+        pos = self.btn_burger.mapToGlobal(self.btn_burger.rect().bottomLeft())
+        menu.exec(pos)
+
+    def _on_item_clicked(self, item: QListWidgetItem) -> None:
+        if item is None:
+            return
+        idx = self.list_widget.row(item)
+        self._active_index = idx
+        self.view_selected.emit(idx)
+
+    # ---------------------------------------------------------------- helpers
+    def _apply_thickness(self) -> None:
+        if self._orientation == "top":
+            height = 64 if self._collapsed else max(96, self.sizeHint().height())
+            self.setFixedHeight(height)
+        else:
+            width = 68 if self._collapsed else self._thickness
+            self.setFixedWidth(width)
+
+    def _update_logo(self) -> None:
+        pixmap = QPixmap(self._logo_path) if self._logo_path else None
+        has_pixmap = bool(pixmap and not pixmap.isNull())
+        if has_pixmap:
+            size = 48 if self._orientation == "left" else 40
+            scaled = pixmap.scaled(size, size, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+            self.logo_label.setPixmap(scaled)
+            self.logo_label.setText(" ")
+        else:
+            self.logo_label.setPixmap(QPixmap())
+            fallback = "MSK"
+            if self._all_titles:
+                fallback = self._all_titles[0][:3].upper()
+            self.logo_label.setText(fallback)
+        self.logo_label.setProperty("pixmap", has_pixmap)
+        self.logo_label.style().unpolish(self.logo_label)
+        self.logo_label.style().polish(self.logo_label)
+
+    def _update_page_controls(self) -> None:
+        count = self.page_count()
+        self.page_label.setText(
+            tr("Page {current} / {total}", current=self._page + 1, total=max(1, count))
+        )
+        self.btn_prev.setEnabled(self._page > 0)
+        self.btn_next.setEnabled(self._page < count - 1)
+        self.page_widget.setVisible(not self._collapsed and count > 1)
+
+    def _update_empty_state(self) -> None:
+        show_list = not self._collapsed and bool(self._all_titles)
+        self.list_widget.setVisible(show_list)
+        self.empty_label.setVisible(not self._collapsed and not self._all_titles)
+
+    # ---------------------------------------------------------------- locale
+    def retranslate_ui(self) -> None:
+        self.caption_label.setText(tr("Sources"))
+        self.subtitle_label.setText(tr("Select a source to display"))
+        self.empty_label.setText(tr("No sources configured yet"))
+        self.btn_toggle.setText(tr("Switch layout"))
+        self.btn_toggle.setToolTip(tr("Toggle between wall and focus view"))
+        self.btn_settings.setText(tr("Settings"))
+        self.btn_settings.setToolTip(tr("Open settings"))
+        self.btn_prev.setToolTip(tr("Previous page"))
+        self.btn_next.setToolTip(tr("Next page"))
+        self._update_page_controls()
+

--- a/kiosk_app/modules/ui/theme.py
+++ b/kiosk_app/modules/ui/theme.py
@@ -1,0 +1,374 @@
+"""Central theme palette helpers for the modern MultiScreenKiosk UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ThemePalette:
+    """Color palette describing the modern kiosk look."""
+
+    name: str
+    background: str
+    surface: str
+    surface_alt: str
+    surface_strong: str
+    text_primary: str
+    text_secondary: str
+    text_muted: str
+    border: str
+    border_strong: str
+    accent: str
+    accent_hover: str
+    accent_text: str
+    accent_soft: str
+    danger: str
+    danger_hover: str
+    danger_text: str
+    nav_background: str
+    nav_border: str
+    nav_hover: str
+    nav_active: str
+    nav_text: str
+    nav_text_inactive: str
+    header_background: str
+    header_border: str
+    header_text: str
+    badge_background: str
+    badge_text: str
+    badge_alt_background: str
+    badge_alt_text: str
+    placeholder_bg: str
+    placeholder_text: str
+
+
+LIGHT_PALETTE = ThemePalette(
+    name="light",
+    background="#f8fafc",
+    surface="#ffffff",
+    surface_alt="#f1f5f9",
+    surface_strong="#e2e8f0",
+    text_primary="#0f172a",
+    text_secondary="#475569",
+    text_muted="#94a3b8",
+    border="#e2e8f0",
+    border_strong="#cbd5e1",
+    accent="#2563eb",
+    accent_hover="#1d4ed8",
+    accent_text="#f8fafc",
+    accent_soft="rgba(37, 99, 235, 0.12)",
+    danger="#ef4444",
+    danger_hover="#dc2626",
+    danger_text="#ffffff",
+    nav_background="#ffffff",
+    nav_border="#e2e8f0",
+    nav_hover="rgba(37, 99, 235, 0.1)",
+    nav_active="#dbeafe",
+    nav_text="#0f172a",
+    nav_text_inactive="#64748b",
+    header_background="#ffffff",
+    header_border="#e2e8f0",
+    header_text="#0f172a",
+    badge_background="rgba(37, 99, 235, 0.12)",
+    badge_text="#1d4ed8",
+    badge_alt_background="rgba(15, 23, 42, 0.08)",
+    badge_alt_text="#0f172a",
+    placeholder_bg="#e2e8f0",
+    placeholder_text="#475569",
+)
+
+
+DARK_PALETTE = ThemePalette(
+    name="dark",
+    background="#0b1120",
+    surface="#111827",
+    surface_alt="#18223a",
+    surface_strong="#1f2937",
+    text_primary="#f8fafc",
+    text_secondary="#cbd5f5",
+    text_muted="#64748b",
+    border="#1f2937",
+    border_strong="#334155",
+    accent="#6366f1",
+    accent_hover="#4f46e5",
+    accent_text="#f8fafc",
+    accent_soft="rgba(99, 102, 241, 0.18)",
+    danger="#f87171",
+    danger_hover="#ef4444",
+    danger_text="#0b1120",
+    nav_background="#0f172a",
+    nav_border="#1f2937",
+    nav_hover="rgba(99, 102, 241, 0.18)",
+    nav_active="#312e81",
+    nav_text="#e2e8f0",
+    nav_text_inactive="#94a3b8",
+    header_background="#111827",
+    header_border="#1f2937",
+    header_text="#f8fafc",
+    badge_background="rgba(99, 102, 241, 0.18)",
+    badge_text="#c7d2fe",
+    badge_alt_background="rgba(148, 163, 184, 0.16)",
+    badge_alt_text="#f8fafc",
+    placeholder_bg="#1f2937",
+    placeholder_text="#94a3b8",
+)
+
+
+def get_palette(theme: str | None) -> ThemePalette:
+    """Return the palette for *theme* (defaults to light)."""
+
+    if str(theme or "").lower().startswith("dark"):
+        return DARK_PALETTE
+    return LIGHT_PALETTE
+
+
+def build_application_stylesheet(palette: ThemePalette) -> str:
+    """Generate the shared Qt stylesheet for the application widgets."""
+
+    p = palette
+    return f"""
+    QWidget {{
+        background-color: {p.background};
+        color: {p.text_primary};
+        font-family: 'Segoe UI', 'Inter', 'Noto Sans', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+    }}
+    QDialog {{
+        background-color: {p.surface};
+    }}
+    QFrame#NavigationPanel {{
+        background-color: {p.nav_background};
+        border-right: 1px solid {p.nav_border};
+    }}
+    QFrame#NavigationPanel[orientation="top"] {{
+        border-right: none;
+        border-bottom: 1px solid {p.nav_border};
+    }}
+    QLabel#NavCaption {{
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        color: {p.nav_text_inactive};
+    }}
+    QLabel#NavSubtitle {{
+        font-size: 12px;
+        color: {p.nav_text_inactive};
+    }}
+    QLabel#NavLogo {{
+        background-color: {p.accent_soft};
+        color: {p.accent};
+        font-weight: 700;
+        font-size: 18px;
+        border-radius: 16px;
+        min-width: 48px;
+        min-height: 48px;
+        max-width: 48px;
+        max-height: 48px;
+    }}
+    QLabel#NavLogo[pixmap="true"] {{
+        background: transparent;
+        border-radius: 12px;
+        padding: 0px;
+    }}
+    QListWidget#NavigationList {{
+        background: transparent;
+        border: none;
+        outline: none;
+    }}
+    QListWidget#NavigationList::item {{
+        margin: 4px 8px;
+        padding: 10px 14px;
+        border-radius: 12px;
+        color: {p.nav_text_inactive};
+    }}
+    QListWidget#NavigationList::item:selected {{
+        background: {p.nav_active};
+        color: {p.nav_text};
+    }}
+    QListWidget#NavigationList::item:hover:!selected {{
+        background: {p.nav_hover};
+        color: {p.nav_text};
+    }}
+    QLabel#NavEmpty {{
+        color: {p.nav_text_inactive};
+        border: 1px dashed {p.nav_border};
+        border-radius: 12px;
+        padding: 16px;
+    }}
+    QToolButton, QPushButton {{
+        background: {p.surface_alt};
+        color: {p.text_primary};
+        border: 1px solid {p.border};
+        border-radius: 12px;
+        padding: 8px 12px;
+    }}
+    QToolButton:hover, QPushButton:hover {{
+        background: {p.surface_strong};
+        border-color: {p.border_strong};
+    }}
+    QToolButton:pressed, QPushButton:pressed {{
+        background: {p.surface_alt};
+    }}
+    QToolButton[accent="true"], QPushButton[accent="true"] {{
+        background: {p.accent};
+        color: {p.accent_text};
+        border: none;
+    }}
+    QToolButton[accent="true"]:hover, QPushButton[accent="true"]:hover {{
+        background: {p.accent_hover};
+    }}
+    QPushButton[destructive="true"] {{
+        background: {p.danger};
+        color: {p.danger_text};
+        border: none;
+    }}
+    QPushButton[destructive="true"]:hover {{
+        background: {p.danger_hover};
+    }}
+    QToolButton#NavBurger {{
+        background: transparent;
+        border: none;
+        color: {p.nav_text};
+        padding: 6px;
+    }}
+    QToolButton#NavBurger:hover {{
+        background: {p.nav_hover};
+    }}
+    QToolButton#PageButton {{
+        padding: 6px 10px;
+        min-width: 32px;
+    }}
+    QToolButton#OverlayBurger {{
+        background: {p.surface};
+        border: 1px solid {p.border};
+        border-radius: 12px;
+        padding: 6px 10px;
+    }}
+    QWidget#HeaderBar {{
+        background-color: {p.header_background};
+        border-bottom: 1px solid {p.header_border};
+    }}
+    QLabel#HeaderTitle {{
+        font-size: 22px;
+        font-weight: 600;
+        color: {p.header_text};
+    }}
+    QLabel#HeaderSubtitle {{
+        font-size: 13px;
+        color: {p.text_secondary};
+    }}
+    QLabel#ModeBadge {{
+        background: {p.badge_background};
+        color: {p.badge_text};
+        font-weight: 600;
+        font-size: 12px;
+        border-radius: 999px;
+        padding: 4px 12px;
+    }}
+    QLabel#ModeBadge[mode="single"] {{
+        background: {p.badge_alt_background};
+        color: {p.badge_alt_text};
+    }}
+    QLabel#ModeBadge[mode="wall"] {{
+        background: {p.accent_soft};
+        color: {p.accent};
+    }}
+    QLabel#StatusBadge {{
+        background: {p.badge_alt_background};
+        color: {p.badge_alt_text};
+        font-weight: 600;
+        font-size: 12px;
+        border-radius: 999px;
+        padding: 4px 12px;
+    }}
+    QLabel#StatusBadge[status="kiosk"] {{
+        background: {p.accent_soft};
+        color: {p.accent};
+    }}
+    QFrame#ContentCard {{
+        background: {p.surface};
+        border: 1px solid {p.border};
+        border-radius: 20px;
+    }}
+    QLabel#EmptySlot {{
+        background: {p.placeholder_bg};
+        color: {p.placeholder_text};
+        border: 1px dashed {p.border_strong};
+        border-radius: 16px;
+        font-size: 16px;
+        letter-spacing: 0.02em;
+    }}
+    QLabel#BrowserPlaceholder {{
+        color: {p.placeholder_text};
+    }}
+    QLineEdit, QComboBox, QSpinBox, QTextEdit, QPlainTextEdit {{
+        background: {p.surface_alt};
+        border: 1px solid {p.border};
+        border-radius: 10px;
+        padding: 8px 10px;
+        color: {p.text_primary};
+    }}
+    QLineEdit:focus, QComboBox:focus, QTextEdit:focus, QPlainTextEdit:focus {{
+        border-color: {p.accent};
+    }}
+    QCheckBox {{
+        spacing: 8px;
+    }}
+    QCheckBox::indicator {{
+        width: 18px;
+        height: 18px;
+        border-radius: 6px;
+        border: 1px solid {p.border_strong};
+        background: {p.surface_alt};
+    }}
+    QCheckBox::indicator:checked {{
+        background: {p.accent};
+        border-color: {p.accent};
+    }}
+    QMenu {{
+        background: {p.surface};
+        border: 1px solid {p.border};
+        padding: 6px 0px;
+        border-radius: 10px;
+    }}
+    QMenu::item {{
+        padding: 6px 18px;
+        color: {p.text_primary};
+    }}
+    QMenu::item:selected {{
+        background: {p.accent_soft};
+        color: {p.accent};
+    }}
+    QScrollBar:vertical {{
+        width: 10px;
+        background: transparent;
+        margin: 6px 2px 6px 2px;
+    }}
+    QScrollBar::handle:vertical {{
+        background: {p.surface_strong};
+        border-radius: 6px;
+    }}
+    QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{
+        height: 0px;
+    }}
+    QScrollBar:horizontal {{
+        height: 10px;
+        background: transparent;
+        margin: 2px 6px 2px 6px;
+    }}
+    QScrollBar::handle:horizontal {{
+        background: {p.surface_strong};
+        border-radius: 6px;
+    }}
+    QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {{
+        width: 0px;
+    }}
+    """
+
+
+def build_dialog_stylesheet(palette: ThemePalette) -> str:
+    """Alias for compatibility with dialogs (currently same as application)."""
+
+    return build_application_stylesheet(palette)
+


### PR DESCRIPTION
## Summary
- add a reusable theme palette module that provides a unified stylesheet for the app
- rebuild the sidebar and main window shell with a header, badges, and responsive navigation controls
- refresh dialogs, log viewer, and placeholders to follow the modernized visual language

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c952d879f08327b3e4c142a81f6e46