### PR TITLE
Bundle MSVC runtime in PyInstaller build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!MultiScreenKiosk.spec
 
 # Installer logs
 pip-log.txt


### PR DESCRIPTION
## Summary
- add a dedicated PyInstaller spec that bundles the default config, assets, PySide6 resources, and the MSVC runtime DLLs needed on clean Windows installs
- allow the tracked spec through .gitignore and document the updated packaging flow and runtime requirements in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd528f515c832784a1b66600ee9b8d