### PR TITLE
Switch application to PyQt5

### DIFF
--- a/MultiScreenKiosk.spec
+++ b/MultiScreenKiosk.spec
@@ -15,11 +15,21 @@ _datas = [
     (str(modules_dir / "assets"), "modules/assets"),
 ]
 
-# Collect PySide6 resources (equivalent to --collect-all PySide6)
-_pyside6_datas, _pyside6_binaries, _pyside6_hiddenimports = collect_all("PySide6")
-_datas += _pyside6_datas
-_binaries = list(_pyside6_binaries)
-_hiddenimports = list(_pyside6_hiddenimports)
+# Collect PyQt5 resources (equivalent to --collect-all PyQt5)
+_pyqt5_datas, _pyqt5_binaries, _pyqt5_hiddenimports = collect_all("PyQt5")
+_datas += _pyqt5_datas
+_binaries = list(_pyqt5_binaries)
+_hiddenimports = list(_pyqt5_hiddenimports)
+
+# Collect PyQtWebEngine resources to ensure QtWebEngine assets are bundled
+_pyqtwe_datas, _pyqtwe_binaries, _pyqtwe_hiddenimports = collect_all("PyQtWebEngine")
+_datas += _pyqtwe_datas
+for binary in _pyqtwe_binaries:
+    if binary not in _binaries:
+        _binaries.append(binary)
+for hidden in _pyqtwe_hiddenimports:
+    if hidden not in _hiddenimports:
+        _hiddenimports.append(hidden)
 
 # Bundle the MSVC runtime so the executable works on clean machines.
 _msvc_dlls = [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MultiScreenKiosk
 
-A production-ready fullscreen kiosk for Windows built with Qt / PySide6 and Qt WebEngine. MultiScreenKiosk lets you combine web
+A production-ready fullscreen kiosk for Windows built with Qt / PyQt5 and Qt WebEngine. MultiScreenKiosk lets you combine web
 content and native Windows applications in a polished kiosk experience that supports both single-view and 2×2 grid layouts.
 
 ---
@@ -62,7 +62,7 @@ Target operating system: **Windows 10 or newer**.
 
 ## Architecture at a glance
 
-- **UI (PySide6):** `MainWindow`, `Sidebar`, `SettingsDialog`, `SetupDialog`, `BrowserHostWidget`
+- **UI (PyQt5):** `MainWindow`, `Sidebar`, `SettingsDialog`, `SetupDialog`, `BrowserHostWidget`
 - **View model:** `AppState` (active index, mode switching)
 - **Services:** `BrowserService` (web views), `LocalAppService` (process spawning, embedding, and watchdog)
 - **Utilities:** configuration loader and asynchronous logger with a bridge to the UI
@@ -72,7 +72,7 @@ Target operating system: **Windows 10 or newer**.
 ## System requirements
 
 - Python **3.10 – 3.13** (64-bit)
-- PySide6 with WebEngine components
+- PyQt5 with the `PyQtWebEngine` package
 
 Install dependencies in a virtual environment:
 
@@ -82,7 +82,7 @@ python -m venv .venv
 py -m pip install -r kiosk_app/modules/requirements.txt
 ```
 
-> If WebEngine is missing, ensure `PySide6-Addons` is installed alongside `PySide6` and `PySide6-Essentials`.
+> If WebEngine is missing, ensure the `PyQtWebEngine` package is installed alongside `PyQt5`.
 
 ---
 
@@ -232,7 +232,7 @@ py -m pip install pyinstaller
 py -m PyInstaller MultiScreenKiosk.spec
 ```
 
-`MultiScreenKiosk.spec` mirrors the command-line flags shown previously, bundles the default `config.json` and splash assets, collects all PySide6 resources, and copies the Microsoft Visual C++ runtime DLLs (`vcruntime140.dll`, `vcruntime140_1.dll`, `msvcp140.dll`). Those DLLs normally live under `<python>\DLLs` inside your active environment or its base interpreter, and Windows keeps a copy in `%SystemRoot%\System32` once the VC++ redistributable is installed. The distributable must ship the runtime or the kiosk will fail to start on machines without the redistributable pre-installed.
+`MultiScreenKiosk.spec` mirrors the command-line flags shown previously, bundles the default `config.json` and splash assets, collects all PyQt5 resources, and copies the Microsoft Visual C++ runtime DLLs (`vcruntime140.dll`, `vcruntime140_1.dll`, `msvcp140.dll`). Those DLLs normally live under `<python>\DLLs` inside your active environment or its base interpreter, and Windows keeps a copy in `%SystemRoot%\System32` once the VC++ redistributable is installed. The distributable must ship the runtime or the kiosk will fail to start on machines without the redistributable pre-installed.
 
 Prefer a one-off command instead of the spec? Let Python calculate the absolute DLL paths (checking the current environment, the base interpreter, and `%SystemRoot%\System32`) before feeding them to `--add-binary` and pointing PyInstaller at `kiosk_app/modules/main.py`:
 
@@ -284,7 +284,7 @@ py -m PyInstaller ^
   --onefile ^
   --add-data "kiosk_app\modules\config.json;config.json" ^
   --add-data "kiosk_app\modules\assets;modules\assets" ^
-  --collect-all PySide6 ^
+  --collect-all PyQt5 ^
   --add-binary "$($dllPaths.'vcruntime140.dll');." ^
   --add-binary "$($dllPaths.'vcruntime140_1.dll');." ^
   --add-binary "$($dllPaths.'msvcp140.dll');." ^
@@ -314,7 +314,7 @@ Create a shortcut to `MultiScreenKiosk.exe` and place it in:
   Python if you plan to run from source) is missing on the target machine. Run
   [`scripts/install_dependencies.ps1`](scripts/install_dependencies.ps1) once from an elevated PowerShell to install the
   required runtimes.
-- **WebEngine fails to load** – ensure `PySide6-Addons` is installed with WebEngine components.
+- **WebEngine fails to load** – ensure the `PyQtWebEngine` package is installed with WebEngine components.
 - **Application does not embed** – run Window Spy and refine regex patterns; confirm the app is not elevated or UWP-only.
 - **Sidebar overlaps content** – disable the hamburger menu in Settings or switch the navigation to the top.
 - **Blank screen after setup** – verify that your active `config.json` contains at least one source definition.
@@ -359,5 +359,5 @@ MIT
 
 ## Credits
 
-Built with **PySide6** and **Qt WebEngine**. Uses Win32 APIs (`SetParent`, `SetWindowPos`, and related calls) for native window
+Built with **PyQt5** and **Qt WebEngine**. Uses Win32 APIs (`SetParent`, `SetWindowPos`, and related calls) for native window
 embedding.

--- a/kiosk_app/modules/README.md
+++ b/kiosk_app/modules/README.md
@@ -1,4 +1,4 @@
-# Kiosk Anwendung fuer Windows mit PySide6
+# Kiosk Anwendung fuer Windows mit PyQt5
 
 ## Features
 - Echter Vollbild Kiosk ohne Rahmen

--- a/kiosk_app/modules/main.py
+++ b/kiosk_app/modules/main.py
@@ -9,8 +9,8 @@ import shutil
 from pathlib import Path
 from typing import Dict, Any, Optional
 
-from PySide6.QtCore import Qt, QTimer
-from PySide6.QtWidgets import QApplication, QDialog
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtWidgets import QApplication, QDialog
 
 from modules.utils.config_loader import (
     load_config,
@@ -230,7 +230,7 @@ def maybe_run_setup(app: QApplication, cfg: Config, cfg_path: Path, force: bool)
 
     log = get_logger(__name__)
     dlg = SetupDialog(cfg)
-    res_code = dlg.exec()
+    res_code = dlg.exec_()
     if res_code != QDialog.Accepted:
         log.info("Setup abgebrochen. Anwendung wird beendet.", extra={"source": "setup"})
         return None
@@ -441,7 +441,7 @@ def main() -> int:
     except Exception:
         win.show()
 
-    result = app.exec()
+    result = app.exec_()
     if splash:
         splash.finish(win)
     return result

--- a/kiosk_app/modules/requirements.txt
+++ b/kiosk_app/modules/requirements.txt
@@ -1,4 +1,5 @@
-PySide6>=6.6
+PyQt5>=5.15
+PyQtWebEngine>=5.15
 requests>=2.31
 psutil>=5.9
 pytest>=8.0

--- a/kiosk_app/modules/services/browser_services.py
+++ b/kiosk_app/modules/services/browser_services.py
@@ -3,8 +3,8 @@ import time
 import requests
 
 try:  # pragma: no cover - optional Qt dependency
-    from PySide6.QtCore import QTimer, QObject, Signal, QUrl  # type: ignore
-    from PySide6.QtWebEngineWidgets import QWebEngineView  # type: ignore
+    from PyQt5.QtCore import QTimer, QObject, pyqtSignal as Signal, QUrl  # type: ignore
+    from PyQt5.QtWebEngineWidgets import QWebEngineView  # type: ignore
     _QT_AVAILABLE = True
 except Exception:  # pragma: no cover - testing fallback
     _QT_AVAILABLE = False

--- a/kiosk_app/modules/services/local_app_service.py
+++ b/kiosk_app/modules/services/local_app_service.py
@@ -13,9 +13,9 @@ from dataclasses import dataclass
 from threading import Thread, Event
 from typing import Optional, Set, Dict, List
 
-from PySide6.QtCore import Qt, QTimer, QSize, Signal
-from PySide6.QtGui import QWindow
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel
+from PyQt5.QtCore import Qt, QTimer, QSize, pyqtSignal as Signal
+from PyQt5.QtGui import QWindow
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel
 
 from modules.utils.logger import get_logger
 

--- a/kiosk_app/modules/tests/__init__.py
+++ b/kiosk_app/modules/tests/__init__.py
@@ -10,10 +10,10 @@ import types
 
 
 def _install_qtcore_stub():
-    if "PySide6.QtCore" in sys.modules:
-        return sys.modules["PySide6.QtCore"]
+    if "PyQt5.QtCore" in sys.modules:
+        return sys.modules["PyQt5.QtCore"]
 
-    qtcore = types.ModuleType("PySide6.QtCore")
+    qtcore = types.ModuleType("PyQt5.QtCore")
 
     class _DummySignal:
         def __init__(self):
@@ -30,6 +30,9 @@ def _install_qtcore_stub():
                     pass
 
     def Signal(*_args, **_kwargs):  # type: ignore
+        return _DummySignal()
+
+    def pyqtSignal(*_args, **_kwargs):  # type: ignore
         return _DummySignal()
 
     class QObject:  # type: ignore
@@ -55,19 +58,20 @@ def _install_qtcore_stub():
             self._url = url
 
     qtcore.Signal = Signal
+    qtcore.pyqtSignal = pyqtSignal
     qtcore.QObject = QObject
     qtcore.QTimer = QTimer
     qtcore.QUrl = QUrl
-    qtcore.__package__ = "PySide6"
-    sys.modules["PySide6.QtCore"] = qtcore
+    qtcore.__package__ = "PyQt5"
+    sys.modules["PyQt5.QtCore"] = qtcore
     return qtcore
 
 
 def _install_qtwe_stub():
-    if "PySide6.QtWebEngineWidgets" in sys.modules:
-        return sys.modules["PySide6.QtWebEngineWidgets"]
+    if "PyQt5.QtWebEngineWidgets" in sys.modules:
+        return sys.modules["PyQt5.QtWebEngineWidgets"]
 
-    qtwe = types.ModuleType("PySide6.QtWebEngineWidgets")
+    qtwe = types.ModuleType("PyQt5.QtWebEngineWidgets")
 
     class QWebEngineView:  # type: ignore
         def __init__(self):
@@ -87,28 +91,28 @@ def _install_qtwe_stub():
             pass
 
     qtwe.QWebEngineView = QWebEngineView
-    qtwe.__package__ = "PySide6"
-    sys.modules["PySide6.QtWebEngineWidgets"] = qtwe
+    qtwe.__package__ = "PyQt5"
+    sys.modules["PyQt5.QtWebEngineWidgets"] = qtwe
     return qtwe
 
 
 try:
-    import PySide6  # type: ignore
+    import PyQt5  # type: ignore
 except Exception:  # pragma: no cover - provide stub for headless CI
-    stub_pkg = types.ModuleType("PySide6")
+    stub_pkg = types.ModuleType("PyQt5")
     stub_pkg.__path__ = []  # type: ignore[attr-defined]
     stub_pkg.__all__ = ["QtCore", "QtWebEngineWidgets"]
     qtcore = _install_qtcore_stub()
     qtwe = _install_qtwe_stub()
     stub_pkg.QtCore = qtcore
     stub_pkg.QtWebEngineWidgets = qtwe
-    sys.modules["PySide6"] = stub_pkg
+    sys.modules["PyQt5"] = stub_pkg
 else:  # pragma: no cover - augment incomplete Qt installs
     try:
-        from PySide6 import QtCore  # type: ignore
+        from PyQt5 import QtCore  # type: ignore
     except Exception:
-        PySide6.QtCore = _install_qtcore_stub()  # type: ignore[attr-defined]
+        PyQt5.QtCore = _install_qtcore_stub()  # type: ignore[attr-defined]
     try:
-        from PySide6 import QtWebEngineWidgets  # type: ignore
+        from PyQt5 import QtWebEngineWidgets  # type: ignore
     except Exception:
-        PySide6.QtWebEngineWidgets = _install_qtwe_stub()  # type: ignore[attr-defined]
+        PyQt5.QtWebEngineWidgets = _install_qtwe_stub()  # type: ignore[attr-defined]

--- a/kiosk_app/modules/tests/test_services.py
+++ b/kiosk_app/modules/tests/test_services.py
@@ -1,5 +1,5 @@
 from services.browser_service import BrowserService, make_webview
-from PySide6.QtWebEngineWidgets import QWebEngineView
+from PyQt5.QtWebEngineWidgets import QWebEngineView
 
 def test_webview_factory():
     v = make_webview()

--- a/kiosk_app/modules/ui/browser_host.py
+++ b/kiosk_app/modules/ui/browser_host.py
@@ -1,9 +1,9 @@
 from typing import Optional
 
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QMovie
-from PySide6.QtWidgets import QWidget, QStackedLayout, QLabel
-from PySide6.QtWebEngineWidgets import QWebEngineView
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QMovie
+from PyQt5.QtWidgets import QWidget, QStackedLayout, QLabel
+from PyQt5.QtWebEngineWidgets import QWebEngineView
 
 from modules.utils.i18n import tr, i18n
 

--- a/kiosk_app/modules/ui/log_viewer.py
+++ b/kiosk_app/modules/ui/log_viewer.py
@@ -4,9 +4,9 @@ from typing import Optional, List
 
 import os
 import re
-from PySide6.QtCore import Qt, QTimer
-from PySide6.QtGui import QTextCursor
-from PySide6.QtWidgets import (
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtGui import QTextCursor
+from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QComboBox, QLineEdit,
     QCheckBox, QPushButton, QTextEdit, QFileDialog, QMessageBox, QWidget
 )

--- a/kiosk_app/modules/ui/main_window.py
+++ b/kiosk_app/modules/ui/main_window.py
@@ -7,9 +7,9 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from PySide6.QtCore import Qt, QTimer, Signal, Slot
-from PySide6.QtGui import QShortcut, QKeySequence
-from PySide6.QtWidgets import (
+from PyQt5.QtCore import Qt, QTimer, pyqtSignal as Signal, pyqtSlot as Slot
+from PyQt5.QtGui import QShortcut, QKeySequence
+from PyQt5.QtWidgets import (
     QMainWindow, QWidget, QHBoxLayout, QVBoxLayout, QStackedWidget,
     QGridLayout, QLabel, QApplication, QToolButton, QMenu, QMessageBox
 )
@@ -216,7 +216,7 @@ class MainWindow(QMainWindow):
         act_settings = m.addAction(tr("Settings"))
         act_settings.triggered.connect(self.open_settings)
         pos = self.overlay_burger.mapToGlobal(self.overlay_burger.rect().bottomLeft())
-        m.exec(pos)
+        m.exec_(pos)
 
     def _nudge_local_apps(self):
     # nur sichtbare Widgets der aktuellen Ansicht anstossen
@@ -622,7 +622,7 @@ class MainWindow(QMainWindow):
             restore_handler=self._restore_config,
             parent=self
         )
-        if dlg.exec():
+        if dlg.exec_():
             res = dlg.results()
 
             restored_cfg = res.get("restored_config")

--- a/kiosk_app/modules/ui/remote_export_dialog.py
+++ b/kiosk_app/modules/ui/remote_export_dialog.py
@@ -5,8 +5,8 @@ from copy import deepcopy
 import re
 from typing import Dict, List, Optional
 
-from PySide6.QtCore import Qt
-from PySide6.QtWidgets import (
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
     QCheckBox,
     QComboBox,
     QDialog,

--- a/kiosk_app/modules/ui/settings_dialog.py
+++ b/kiosk_app/modules/ui/settings_dialog.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import Optional, Dict, Any, List, Callable, Set
 from copy import deepcopy
 from pathlib import Path
-from PySide6.QtCore import Qt, QPoint, Signal, QTime
-from PySide6.QtGui import QKeySequence
-from PySide6.QtWidgets import (
+from PyQt5.QtCore import Qt, QPoint, pyqtSignal as Signal, QTime
+from PyQt5.QtGui import QKeySequence
+from PyQt5.QtWidgets import (
     QDialog, QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QComboBox, QCheckBox, QLineEdit, QFileDialog, QMessageBox,
     QKeySequenceEdit, QMenu, QGridLayout, QSpinBox, QTableWidget,
@@ -870,11 +870,11 @@ class SettingsDialog(QDialog):
             actions[0].trigger()
             return
         pos = self.btn_config.mapToGlobal(self.btn_config.rect().bottomLeft())
-        self._config_menu.exec(pos)
+        self._config_menu.exec_(pos)
 
     def _open_remote_export_dialog(self):
         dlg = RemoteExportDialog(self._remote_export_settings, self)
-        if dlg.exec():
+        if dlg.exec_():
             result = dlg.result_settings()
             if result is not None:
                 self._remote_export_settings = deepcopy(result)
@@ -882,13 +882,13 @@ class SettingsDialog(QDialog):
 
     def _open_schedule_dialog(self) -> None:
         dlg = ScheduleEditorDialog(self._schedule_payload, self._source_names, self)
-        if dlg.exec():
+        if dlg.exec_():
             self._schedule_payload = dlg.result_schedule()
             self._update_schedule_summary()
 
     def _open_shortcut_dialog(self) -> None:
         dlg = ShortcutEditorDialog(self._shortcut_map, self)
-        if dlg.exec():
+        if dlg.exec_():
             self._shortcut_map = dlg.result_shortcuts()
             self._update_shortcut_summary()
 
@@ -1007,7 +1007,7 @@ class SettingsDialog(QDialog):
         m.setIcon(QMessageBox.Warning)
         m.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         m.setDefaultButton(QMessageBox.No)
-        res = m.exec()
+        res = m.exec_()
 
         if res == QMessageBox.Yes:
             self._result = {

--- a/kiosk_app/modules/ui/setup_dialog.py
+++ b/kiosk_app/modules/ui/setup_dialog.py
@@ -4,8 +4,8 @@ from typing import List, Dict, Any, Optional
 import copy
 from dataclasses import asdict, is_dataclass
 
-from PySide6.QtCore import Qt
-from PySide6.QtWidgets import (
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
     QDialog, QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QComboBox, QCheckBox, QLineEdit, QFileDialog, QScrollArea, QMessageBox,
     QSpinBox, QGridLayout

--- a/kiosk_app/modules/ui/sidebar.py
+++ b/kiosk_app/modules/ui/sidebar.py
@@ -1,8 +1,8 @@
 from typing import List, Optional
 
-from PySide6.QtCore import QSize, Qt, QRectF, Signal
-from PySide6.QtGui import QPixmap, QPainter, QTransform, QKeySequence
-from PySide6.QtWidgets import (
+from PyQt5.QtCore import QSize, Qt, QRectF, pyqtSignal as Signal
+from PyQt5.QtGui import QPixmap, QPainter, QTransform, QKeySequence
+from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QToolButton, QPushButton,
     QFrame, QSizePolicy, QMenu
 )
@@ -311,7 +311,7 @@ class Sidebar(QWidget):
             m.addSeparator()
             act_settings = m.addAction(tr("Settings"))
             act_settings.triggered.connect(self.request_settings.emit)
-            m.exec(self.mapToGlobal(self.btn_burger.geometry().bottomLeft()))
+            m.exec_(self.mapToGlobal(self.btn_burger.geometry().bottomLeft()))
 
     def set_collapsed(self, collapsed: bool):
         self._collapsed = collapsed

--- a/kiosk_app/modules/ui/splash_screen.py
+++ b/kiosk_app/modules/ui/splash_screen.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
-from PySide6.QtCore import Qt, QTimer, QUrl
-from PySide6.QtGui import QGuiApplication, QMovie
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QWidget
+from PyQt5.QtCore import Qt, QTimer, QUrl
+from PyQt5.QtGui import QGuiApplication, QMovie
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QWidget
 
 from modules.utils.i18n import tr
 from modules.utils.logger import get_logger
 
 try:  # pragma: no cover - optional dependency during tests
-    from PySide6.QtLottie import QLottieAnimation  # type: ignore
+    from PyQt5.QtLottie import QLottieAnimation  # type: ignore
     _HAS_QT_LOTTIE = True
 except Exception:  # pragma: no cover - optional dependency
     QLottieAnimation = None  # type: ignore[assignment]

--- a/kiosk_app/modules/ui/views.py
+++ b/kiosk_app/modules/ui/views.py
@@ -1,6 +1,6 @@
 from typing import List
-from PySide6.QtCore import Qt, QPropertyAnimation, QEasingCurve, QParallelAnimationGroup, QRect
-from PySide6.QtWidgets import QWidget, QStackedWidget, QGridLayout, QVBoxLayout, QLabel, QSizePolicy
+from PyQt5.QtCore import Qt, QPropertyAnimation, QEasingCurve, QParallelAnimationGroup, QRect
+from PyQt5.QtWidgets import QWidget, QStackedWidget, QGridLayout, QVBoxLayout, QLabel, QSizePolicy
 from modules.utils.i18n import tr, i18n
 
 class LoadingOverlay(QWidget):

--- a/kiosk_app/modules/ui/window_spy.py
+++ b/kiosk_app/modules/ui/window_spy.py
@@ -3,8 +3,8 @@ from typing import Optional, List, Tuple, Set
 import ctypes
 from ctypes import wintypes
 
-from PySide6.QtCore import Qt
-from PySide6.QtWidgets import (
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QCheckBox,
     QTableWidget, QTableWidgetItem, QLabel, QMessageBox, QAbstractItemView, QWidget
 )

--- a/kiosk_app/modules/utils/i18n.py
+++ b/kiosk_app/modules/utils/i18n.py
@@ -2,7 +2,7 @@ import json
 import locale
 from typing import Dict, Iterable, List, NamedTuple
 
-from PySide6.QtCore import QObject, Signal
+from PyQt5.QtCore import QObject, pyqtSignal as Signal
 
 from modules.utils.resource_loader import get_resource_dir
 

--- a/kiosk_app/modules/utils/logger.py
+++ b/kiosk_app/modules/utils/logger.py
@@ -19,7 +19,7 @@ from modules.utils.remote_export import RemoteLogExporter, RemoteExportResult, R
 
 # Qt Bridge optional
 try:
-    from PySide6.QtCore import QObject, Signal, QCoreApplication  # type: ignore
+    from PyQt5.QtCore import QObject, pyqtSignal as Signal, QCoreApplication  # type: ignore
     _HAVE_QT = True
 except Exception:
     _HAVE_QT = False
@@ -379,7 +379,7 @@ def _install_qt_message_handler():
     if not _HAVE_QT:
         return
     try:
-        from PySide6.QtCore import qInstallMessageHandler  # type: ignore
+        from PyQt5.QtCore import qInstallMessageHandler  # type: ignore
     except Exception:
         return
 


### PR DESCRIPTION
## Summary
- replace all PySide6 usage with PyQt5 equivalents across the application and update signal/slot handling
- refresh packaging, requirements, and documentation to depend on PyQt5/PyQtWebEngine and collect the appropriate resources for builds
- adjust test shims for PyQt5 and ensure dialogs use exec_ helpers required by PyQt5

## Testing
- pytest kiosk_app/modules/tests

------
https://chatgpt.com/codex/tasks/task_e_68d0fc683a348327876a94bd2314efb0