### PR TITLE
Fix QShortcut import location

### DIFF
--- a/kiosk_app/modules/ui/main_window.py
+++ b/kiosk_app/modules/ui/main_window.py
@@ -8,10 +8,11 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from PyQt5.QtCore import Qt, QTimer, pyqtSignal as Signal, pyqtSlot as Slot
-from PyQt5.QtGui import QShortcut, QKeySequence
+from PyQt5.QtGui import QKeySequence
 from PyQt5.QtWidgets import (
     QMainWindow, QWidget, QHBoxLayout, QVBoxLayout, QStackedWidget,
-    QGridLayout, QLabel, QApplication, QToolButton, QMenu, QMessageBox
+    QGridLayout, QLabel, QApplication, QToolButton, QMenu, QMessageBox,
+    QShortcut,
 )
 
 from modules.ui.app_state import AppState, ViewMode


### PR DESCRIPTION
## Summary
- import QShortcut from PyQt5.QtWidgets instead of PyQt5.QtGui so the module is available at runtime

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1017b71f883278129df0f7a8a1faa